### PR TITLE
Feature: Fetch color schemes from iTerm2-Color-Schemes repository and display the color themes and palettes for each selection

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -7,6 +7,7 @@
         "": {
             "name": "ghostty-config",
             "version": "0.0.1",
+            "license": "Apache-2.0",
             "dependencies": {
                 "@fontsource-variable/inter": "^5.0.20"
             },

--- a/src/lib/components/settings/Dropdown.svelte
+++ b/src/lib/components/settings/Dropdown.svelte
@@ -1,14 +1,15 @@
 <script lang="ts">
     type Props = {
         value: string;
-        options: (string | {name: string, value: string})[]
+        options: (string | {name: string, value: string})[];
+        change?: () => void;
     };
 
     // eslint-disable-next-line prefer-const
-    let {value = $bindable(), options}: Props = $props();
+    let {value = $bindable(), options, change}: Props = $props();
 </script>
 
-<select bind:value>
+<select bind:value onchange={change}>
     {#each options as option, i (i)}
         {#if typeof(option) === "string"}
             <option value={option}>{option}</option>

--- a/src/lib/components/settings/Theme.svelte
+++ b/src/lib/components/settings/Theme.svelte
@@ -1,0 +1,18 @@
+<script lang="ts">
+    import {setColorScheme} from "$lib/stores/config.svelte";
+    import Dropdown from "./Dropdown.svelte";
+
+    type Props = {
+        value: string;
+        options: (string | {name: string, value: string})[]
+    };
+
+    // eslint-disable-next-line prefer-const
+    let {value = $bindable(), options}: Props = $props();
+
+    async function change() {
+        await setColorScheme(value);
+    }
+</script>
+
+<Dropdown bind:value {options} {change} />

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -70,9 +70,28 @@ interface Keybinds extends BaseSettingItem {
     type: "keybinds";
 }
 
+interface ThemeResponse {
+  "type": string;
+  "encoding": string;
+  "size": number;
+  "name": string;
+  "path": string;
+  "content": string;
+  "sha": string;
+  "url": string;
+  "git_url": string;
+  "html_url": string;
+  "download_url": string;
+  "_links": {
+    "git": string;
+    "self": string;
+    "html": string;
+  }
+}
+
 const {themeFiles} = await load();
 
-const themeFileNames = themeFiles.map((file: { name: string; }) => file.name.replace(".txt", ""));
+const themeFileNames = themeFiles.map((file: ThemeResponse) => file.name);
 
 export default [
     {

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -1,4 +1,5 @@
 import type {HexColor} from "$lib/utils/colors";
+import {load} from "../../routes/+page";
 
 interface BaseSettingType {
     id: string;
@@ -68,6 +69,10 @@ interface Keybinds extends BaseSettingItem {
     value: KeybindString[];
     type: "keybinds";
 }
+
+const {themeFiles} = await load();
+
+const themeFileNames = themeFiles.map((file: { name: string; }) => file.name.replace(".txt", ""));
 
 export default [
     {
@@ -212,7 +217,14 @@ export default [
                 id: "general",
                 name: "",
                 settings: [
-                    {id: "theme", name: "Color theme", note: "Any colors selected after setting this will overwrite the theme's colors.", type: "text", value: ""},
+                    {
+                        id: "theme",
+                        name: "Color theme",
+                        note: "Any colors selected after setting this will overwrite the theme's colors.",
+                        type: "dropdown",
+                        value: "",
+                        options: ["", ...themeFileNames]
+                    },
                     {id: "boldIsBright", name: "Bold text uses bright colors", type: "switch", value: false},
                     {id: "minimumContrast", name: "Minimum contrast", type: "number", value: 1, range: true, min: 1, max: 21, step: 0.1},
                 ]

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -185,9 +185,6 @@ export const fetchColorScheme = async (theme: string) => {
 const {themeFiles} = await fetchThemeFiles();
 const themeFileNames = themeFiles && themeFiles.map((file: ThemeResponse) => file.name);
 
-// const {colorSchemeResponse} = await fetchColorScheme("Abernathy");
-// const colorScheme = parseColorScheme(colorSchemeResponse);
-
 export default [
     {
         id: "application",

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -143,7 +143,7 @@ const parseColorScheme = (input: string): ColorScheme => {
           colorScheme.cursorColor = `#${value}`;
           break;
         case "selection-background":
-          colorScheme.selectionBackground = `#${value}`;;
+          colorScheme.selectionBackground = `#${value}`;
           break;
         case "selection-foreground":
           colorScheme.selectionForeground = `#${value}`;

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -1,5 +1,4 @@
 import type {HexColor} from "$lib/utils/colors";
-import {load} from "../../routes/+page";
 
 interface BaseSettingType {
     id: string;
@@ -89,9 +88,23 @@ interface ThemeResponse {
   }
 }
 
-const {themeFiles} = await load();
+const fetchThemeFiles = async () => {
+    const apiUrl = "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
 
-const themeFileNames = themeFiles.map((file: ThemeResponse) => file.name);
+    const response = await fetch(apiUrl);
+
+    if (!response.ok) {
+        throw new Error(`Error fetching data: ${response.statusText}`);
+    }
+
+    const themeFiles = await response.json();
+
+    return {themeFiles};
+};
+
+const {themeFiles} = await fetchThemeFiles();
+
+const themeFileNames = themeFiles && themeFiles.map((file: ThemeResponse) => file.name);
 
 export default [
     {

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -11,11 +11,11 @@ interface Panel extends BaseSettingType {
 }
 
 interface Group extends BaseSettingType {
-    settings: (Switch | Text | Number | Dropdown | Color | Palette | Keybinds)[];
+    settings: (Switch | Text | Number | Dropdown | Color | Palette | Keybinds | Theme)[];
     // type: "group";
 }
 
-type SettingType = "switch" | "number" | "dropdown" | "text" | "color" | "palette" | "keybinds";
+type SettingType = "switch" | "number" | "dropdown" | "text" | "color" | "palette" | "keybinds" | "theme";
 
 interface BaseSettingItem extends BaseSettingType {
     type: SettingType;
@@ -49,6 +49,12 @@ interface DropdownOption {
 
 interface Dropdown extends BaseSettingItem {
     type: "dropdown";
+    value: "string";
+    options: (DropdownOption | string)[];
+}
+
+interface Theme extends BaseSettingItem {
+    type: "theme";
     value: "string";
     options: (DropdownOption | string)[];
 }
@@ -88,13 +94,13 @@ interface ThemeResponse {
   }
 }
 
-interface ColorScheme {
-  palette: { [key: string]: string };
-  background?: string;
-  foreground?: string;
-  cursorColor?: string;
-  selectionBackground?: string;
-  selectionForeground?: string;
+export interface ColorScheme {
+  palette: HexColor[];
+  background?: HexColor;
+  foreground?: HexColor;
+  cursorColor?: HexColor;
+  selectionBackground?: HexColor;
+  selectionForeground?: HexColor;
 }
 
 const fetchThemeFiles = async () => {
@@ -112,8 +118,8 @@ const fetchThemeFiles = async () => {
 };
 
 // Function to convert raw string data into a JSON object
-const parseColorScheme = (input: string): ColorScheme => {
-  const colorScheme: ColorScheme = {palette: {}};
+export const parseColorScheme = (input: string): ColorScheme => {
+  const colorScheme: ColorScheme = {palette: Array(256)};
 
   // Split input by lines
   const lines = input.split("\n");
@@ -125,7 +131,8 @@ const parseColorScheme = (input: string): ColorScheme => {
       if (rest) {
         const [paletteIndex, color] = rest.split("=");
         if (paletteIndex && color) {
-          colorScheme.palette[paletteIndex.trim()] = color.trim();
+          const index = parseInt(paletteIndex.trim());
+          colorScheme.palette[index] = color.trim() as HexColor;
         }
       }
     }
@@ -157,7 +164,7 @@ const parseColorScheme = (input: string): ColorScheme => {
   return colorScheme;
 };
 
-const fetchColorScheme = async (theme: string) => {
+export const fetchColorScheme = async (theme: string) => {
     const apiUrl = `https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty${theme ? "/" + theme : ""}`;
 
     const response = await fetch(apiUrl,{
@@ -178,8 +185,8 @@ const fetchColorScheme = async (theme: string) => {
 const {themeFiles} = await fetchThemeFiles();
 const themeFileNames = themeFiles && themeFiles.map((file: ThemeResponse) => file.name);
 
-const {colorSchemeResponse} = await fetchColorScheme("Abernathy");
-const colorScheme = parseColorScheme(colorSchemeResponse);
+// const {colorSchemeResponse} = await fetchColorScheme("Abernathy");
+// const colorScheme = parseColorScheme(colorSchemeResponse);
 
 export default [
     {
@@ -328,7 +335,7 @@ export default [
                         id: "theme",
                         name: "Color theme",
                         note: "Any colors selected after setting this will overwrite the theme's colors.",
-                        type: "dropdown",
+                        type: "theme",
                         value: "",
                         options: ["", ...themeFileNames]
                     },

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -1,5 +1,5 @@
 import {dev} from "$app/environment";
-import settings, {type KeybindString} from "$lib/data/settings";
+import settings, {fetchColorScheme, parseColorScheme, type KeybindString, type ColorScheme} from "$lib/data/settings";
 import type {HexColor} from "$lib/utils/colors";
 // import defs from "../data/defaults.json";
 
@@ -71,6 +71,33 @@ export function load(conf: Partial<typeof config>) {
                 config.palette[p] = conf.palette[p];
             }
         }
+    }
+}
+
+export async function setColorScheme(name: string) {
+    if (name === "") return resetColorScheme();
+    const {colorSchemeResponse} = await fetchColorScheme(name);
+    const colorScheme = parseColorScheme(colorSchemeResponse);
+    const keys = ["background", "foreground", "cursorColor", "selectionBackground", "selectionForeground"] as (keyof ColorScheme)[];
+    for (const key of keys) {
+        if (!colorScheme[key]) continue;
+        config[key] = colorScheme[key];
+    }
+
+    for (let c = 0; c < colorScheme.palette.length; c++) {
+        if (!colorScheme.palette[c]) continue;
+        config.palette[c] = colorScheme.palette[c];
+    }
+}
+
+export async function resetColorScheme() {
+    const keys = ["background", "foreground", "cursorColor", "selectionBackground", "selectionForeground"] as (keyof DefaultConfig)[];
+    for (const key of keys) {
+        config[key] = defaults[key];
+    }
+
+    for (let c = 0; c < defaults.palette.length; c++) {
+        config.palette[c] = defaults.palette[c];
     }
 }
 

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,17 +1,3 @@
 // since there's no dynamic data here, we can prerender
 // it so that it gets served as a static asset in production
-// export const prerender = true;
-
-export const load = async () => {
-    const apiUrl = "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
-
-    const response = await fetch(apiUrl);
-
-    if (!response.ok) {
-        throw new Error(`Error fetching data: ${response.statusText}`);
-    }
-
-    const themeFiles = await response.json();
-
-    return {themeFiles};
-};
+export const prerender = true;

--- a/src/routes/+page.ts
+++ b/src/routes/+page.ts
@@ -1,3 +1,17 @@
 // since there's no dynamic data here, we can prerender
 // it so that it gets served as a static asset in production
-export const prerender = true;
+// export const prerender = true;
+
+export const load = async () => {
+    const apiUrl = "https://api.github.com/repos/mbadolato/iTerm2-Color-Schemes/contents/ghostty";
+
+    const response = await fetch(apiUrl);
+
+    if (!response.ok) {
+        throw new Error(`Error fetching data: ${response.statusText}`);
+    }
+
+    const themeFiles = await response.json();
+
+    return {themeFiles};
+};

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -19,6 +19,7 @@
     import CursorPreview from "$lib/views/CursorPreview.svelte";
     import PalettePreview from "$lib/views/PalettePreview.svelte";
     import Admonition from "$lib/components/Admonition.svelte";
+    import Theme from "$lib/components/settings/Theme.svelte";
 
 
     const category = $derived(settings.find(c => c.id === $page.params.category));
@@ -56,6 +57,8 @@
                             <Number bind:value={config[setting.id as keyof typeof config]} range={setting.range} min={setting.min} max={setting.max} step={setting.step} size={setting.size} />
                         {:else if setting.type === "dropdown"}
                             <Dropdown bind:value={config[setting.id as keyof typeof config]} options={setting.options} />
+                        {:else if setting.type === "theme"}
+                            <Theme bind:value={config[setting.id as keyof typeof config]} options={setting.options} />
                         {:else if setting.type === "color"}
                             <Color defaultValue={setting.value} bind:value={config[setting.id as keyof typeof config]} />
                         {:else if setting.type === "palette"}


### PR DESCRIPTION
The following changes fetch the color schemes from the [iTerm2-Color-Schemes](https://github.com/mbadolato/iTerm2-Color-Schemes/tree/master) repository to be used to update the ghostty config with up-to-date color themes.