### PR TITLE
Bugfix: Remove overscroll behavior in body tag

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -97,7 +97,7 @@
 body {
     min-height: 100vh;
     margin: 0;
-    overscroll-behavior: none; /* This line */
+    overscroll-behavior: none;
     background-image: url("$lib/images/monterey.webp");
     background-attachment: fixed;
     background-size: cover;

--- a/src/app.css
+++ b/src/app.css
@@ -97,13 +97,14 @@
 body {
     min-height: 100vh;
     margin: 0;
-	background-image: url("$lib/images/monterey.webp");
-	background-attachment: fixed;
-	background-size: cover;
-	background-position: center center;
-	display: flex;
-	justify-content: center;
-	align-items: center;
+    overscroll-behavior: none; /* This line */
+    background-image: url("$lib/images/monterey.webp");
+    background-attachment: fixed;
+    background-size: cover;
+    background-position: center center;
+    display: flex;
+    justify-content: center;
+    align-items: center;
 }
 
 a {


### PR DESCRIPTION
This following change removes the overscroll behavior in the <body> tag to fix a common issue with the background image not extending when a page is overscrolled.