### PR TITLE
Fix text selection in import/export preview

### DIFF
--- a/src/routes/app/import-export/+page.svelte
+++ b/src/routes/app/import-export/+page.svelte
@@ -150,9 +150,7 @@
 }
 
 .preview .row {
-    display: flex;
     white-space: pre;
-    flex: 1;
     /* width: 100%; */
     /* overflow: hidden; */
 }


### PR DESCRIPTION
Hi!

Right now, the line items in the preview don't highlight/copy cleanly. I see it's not really the intention, given the buttons below, but I thought this made for a nicer UX (e.g. cherry-picking a particular line).

Behavior before and after:

[Kapture 2024-12-29 at 00.51.34.webm](https://github.com/user-attachments/assets/7eb3e791-6aed-42a4-8f0a-d2f69a2563c1)