### PR TITLE
Make copy-on-select option a dropdown

### DIFF
--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -200,7 +200,7 @@ const settings = [
                 settings: [
                     {id: "clipboardRead", name: "Allow terminal to read clipboard", type: "dropdown", value: "ask", options: ["ask", "allow", "deny"]},
                     {id: "clipboardWrite", name: "Allow terminal to write clipboard", type: "dropdown", value: "ask", options: ["ask", "allow", "deny"]},
-                    {id: "copyOnSelect", name: "Copy on select", type: "switch", value: true},
+                    {id: "copyOnSelect", name: "Copy on select", type: "dropdown", value: true, options: ["true", "false", "clipboard"]},
                     {id: "clipboardTrimTrailingSpaces", name: "Trim trailing space on copy", type: "switch", value: true},
                     {id: "clipboardPasteProtection", name: "Confirm when pasting unsafely", type: "switch", value: true},
                     {id: "clipboardPasteBracketedSafe", name: "Mark bracketed paste as safe", type: "switch", value: true},


### PR DESCRIPTION
copy-on-select can now have three values, true, false, and clipboard.

This updates the configurator to off those choices.

**NOTE**: I'm not front-end enough to figure out how to test this....  Hopefully doing half of the work is useful.

Fixes: https://github.com/zerebos/ghostty-config/issues/11