### PR TITLE
fix: prevent extra line breaks when copying config from preview

### DIFF
--- a/src/routes/app/import-export/+page.svelte
+++ b/src/routes/app/import-export/+page.svelte
@@ -150,11 +150,8 @@
 }
 
 .preview .row {
-    display: flex;
+    display: block;
     white-space: pre;
-    flex: 1;
-    /* width: 100%; */
-    /* overflow: hidden; */
 }
 
 /* .bold {font-weight: 700;} */


### PR DESCRIPTION
fixes zerebos/ghostty-config#31