### PR TITLE
Realign the design with macOS

### DIFF
--- a/src/app.css
+++ b/src/app.css
@@ -16,14 +16,28 @@
 
 
     /* Background levels */
-    --bg-level-1: #2C2733;
-    --bg-level-2: #2F2935;
-    --bg-level-3: #332D38;
-    --bg-level-4: #39343F;
-    --bg-separator: #39333F;
+    /* --bg-level-1: #2C2733; */
+    /* --bg-level-1: #2D2C3A; */
+    /*
+    level #313138
+    border outer #55555A
+    border inner #3E3E44
+    separator #3D3D43
+    */
+    --bg-level-1: #2D2D34;
+    /* --bg-level-2: #2F2935; */
+    --bg-level-2: #313138;
+    /* --bg-level-3: #332D38; */
+    --bg-level-3: #36363D;
+    /* --bg-level-4: #39343F; */
+    --bg-level-4: #3E3E43;
+    /* --bg-separator: #39333F; */
+    --bg-separator: #3D3D43;
     --bg-input-focus: #1F1E1F;
     --bg-modal: #231E2A;
     --bg-basic-button: #635F68;
+
+    --bg-level-5: #4A4A50;
 
     /* Corresponding border levels */
     --border-level-1: #000000;

--- a/src/lib/components/settings/Number.svelte
+++ b/src/lib/components/settings/Number.svelte
@@ -50,7 +50,7 @@ input[type="number"]:focus {
 input[type="range"] {
    border: 0;
    height: 5px;
-   background-color: var(--bg-separator);
+   background-color: var(--bg-level-5);
 }
 
 input[type="range"]::-moz-range-progress {

--- a/src/lib/views/Page.svelte
+++ b/src/lib/views/Page.svelte
@@ -65,7 +65,8 @@
     font-size: 16pt;
     gap: 10px;
     padding: 10px 20px 5px 20px;
-    background: rgba(44, 39, 51, 0.9);
+    /* background: rgba(44, 39, 51, 0.9); */
+    background: var(--bg-level-1);
     /* not top: #2E2932 */
     backdrop-filter: blur(20px);
     position: absolute;
@@ -76,7 +77,8 @@
 }
 
 .content-header.scrolling {
-    background: rgba(46, 41, 50, 0.9);
+    /* background: rgba(46, 41, 50, 0.9); */
+    background: rgba(from var(--bg-level-1) r g b / 0.9);
     border-bottom: 1px solid black;
 }
 

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -199,8 +199,10 @@
 #sidebar {
     width: var(--sidebar-width);
     /* black: #272329; white: #544F57; */
-    background: rgba(50, 46, 52, 0.7);
-    backdrop-filter: blur(10px);
+    /* background: rgba(50, 46, 52, 0.7); */
+    /* backdrop-filter: blur(10px); */
+    background: rgba(from var(--bg-level-1) r g b / 0.78);
+    backdrop-filter: blur(20px) saturate(180%);
     padding: 5px;
     border-right: 2px solid var(--border-level-1);
     display: flex;


### PR DESCRIPTION
After toying around with things I found that recent versions of Sequoia have slightly altered the way the window compositor handles the monterey background against the system preferences. They now keep more of their gray rather than having a reddish hue to it. There's also seemingly been a few border radius tweaks that I need to fix up.