### PR TITLE
feat: persist application config to localStorage

### DIFF
--- a/src/app.d.ts
+++ b/src/app.d.ts
@@ -1,5 +1,9 @@
 // See https://kit.svelte.dev/docs/types#app
 // for information about these interfaces
+interface ImportMetaEnv {
+    readonly VITE_PERSIST_STATE: string;
+}
+
 declare global {
     namespace App {
         // interface Error {}

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -24,8 +24,10 @@ if (dev) {
 const config = $state(Object.assign({}, defaults));
 
 const STORAGE_KEY = "ghostty-config";
+const PERSIST_ENABLED = import.meta.env.VITE_PERSIST_STATE !== "false";
 
 function saveToStorage() {
+    if (!PERSIST_ENABLED) return;
     const d = diff();
     if (Object.keys(d).length === 0) {
         localStorage.removeItem(STORAGE_KEY);
@@ -36,6 +38,7 @@ function saveToStorage() {
 }
 
 function loadFromStorage() {
+    if (!PERSIST_ENABLED) return;
     const saved = localStorage.getItem(STORAGE_KEY);
     if (!saved) return;
     try {

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -23,6 +23,45 @@ if (dev) {
 
 const config = $state(Object.assign({}, defaults));
 
+const STORAGE_KEY = "ghostty-config";
+
+function saveToStorage() {
+    const d = diff();
+    if (Object.keys(d).length === 0) {
+        localStorage.removeItem(STORAGE_KEY);
+    }
+    else {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(d));
+    }
+}
+
+function loadFromStorage() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    try {
+        const parsed = JSON.parse(saved) as Partial<typeof config>;
+        // Convert kebab-case keys back to camelCase
+        const converted: Record<string, unknown> = {};
+        for (const key in parsed) {
+            const camelKey = key.replaceAll(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+            converted[camelKey] = parsed[key as keyof typeof parsed];
+        }
+        load(converted as Partial<typeof config>);
+    }
+    catch {
+        // Ignore corrupt data
+    }
+}
+
+loadFromStorage();
+
+$effect.root(() => {
+    $effect(() => {
+        // Access config deeply to track all changes
+        JSON.stringify(config);
+        saveToStorage();
+    });
+});
 
 export function keyToConfig(key: string) {
     return key.replaceAll(/([A-Z])/g, "-$1").toLowerCase();


### PR DESCRIPTION
Adds automatic persistence of user config changes to `localStorage`, so settings survive page refreshes and browser restarts.

## How it works

| Concern | Implementation |
|---|---|
| **Storage key** | `ghostty-config` in `localStorage` |
| **What's stored** | Only values that differ from defaults (via existing `diff()`) |
| **Serialization** | JSON with kebab-case keys (matching Ghostty's config format) |
| **Restore** | On module init, reads from storage, converts kebab→camelCase, and feeds into existing `load()` |
| **Auto-save** | `$effect.root` + `$effect` with deep tracking via `JSON.stringify(config)` |
| **Toggle** | `VITE_PERSIST_STATE` env var — enabled by default, set to `"false"` to disable |

## Changes

### `src/lib/stores/config.svelte.ts`
- **`saveToStorage()`** — serializes config diff to localStorage; removes the entry entirely when config matches defaults (no stale data)
- **`loadFromStorage()`** — restores saved config on initialization with kebab-to-camelCase key conversion; silently ignores corrupt data
- **`$effect.root` reactive scope** — auto-saves on every config change using deep `$state` tracking
- **`PERSIST_ENABLED` flag** — reads `VITE_PERSIST_STATE` env var to gate both save and load

### `src/app.d.ts`
- Declares `ImportMetaEnv` interface with `VITE_PERSIST_STATE` for TypeScript support

## Design decisions

- **Opt-out pattern**: Persistence is on by default (`!== "false"`) so it works out of the box — the env var only needs to be set when explicitly disabling
- **Diff-only storage**: Storing only changed values keeps localStorage minimal and avoids issues when defaults change across versions
- **Reuses existing `load()`/`diff()`**: No new serialization logic — leverages the same functions used by the Import & Export page
- **SSR-safe**: The app already has `ssr = false`, so `localStorage` is always available

## Usage

```sh
# Default: persistence enabled
npm run dev

# Disable persistence
VITE_PERSIST_STATE=false npm run build
```