### PR TITLE
feat: add setting description popovers on hover

### DIFF
--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,12 +1,62 @@
 <script lang="ts">
     import type {Snippet} from "svelte";
+    import {scale} from "svelte/transition";
+    import {getSettingDescription} from "$lib/utils/schema";
 
-    const {name = "", note = "", children}: {name?: string, note?: string, children: Snippet} = $props();
+    const {name = "", note = "", settingId = "", children}: {name?: string, note?: string, settingId?: string, children: Snippet} = $props();
+
+    const description = $derived(settingId ? getSettingDescription(settingId) : undefined);
+
+    let showInfo = $state(false);
+    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
+    let iconEl: HTMLSpanElement | undefined = $state();
+    let popoverStyle = $state("");
+
+    function updatePosition() {
+        if (!iconEl) return;
+        const rect = iconEl.getBoundingClientRect();
+        const popoverWidth = 320;
+
+        let left = rect.left;
+        if (left + popoverWidth > window.innerWidth - 12) {
+            left = window.innerWidth - popoverWidth - 12;
+        }
+
+        popoverStyle = `top: ${rect.bottom + 8}px; left: ${left}px;`;
+    }
+
+    function handleMouseEnter() {
+        clearTimeout(hideTimeout);
+        updatePosition();
+        showInfo = true;
+    }
+
+    function handleMouseLeave() {
+        hideTimeout = setTimeout(() => { showInfo = false; }, 150);
+    }
 </script>
 
 <div class="setting-item">
     <div class="row">
-        {#if name}<div class="setting-name">{name}</div>{/if}
+        {#if name}
+            <div class="setting-name">
+                {name}
+                {#if description}
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <span
+                        class="info-btn"
+                        bind:this={iconEl}
+                        onmouseenter={handleMouseEnter}
+                        onmouseleave={handleMouseLeave}
+                        aria-label="More info about {name}"
+                    >
+                        <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm1 12H7V7h2v5zM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+                        </svg>
+                    </span>
+                {/if}
+            </div>
+        {/if}
         <div class="setting">{@render children()}</div>
     </div>
     {#if note}
@@ -15,6 +65,19 @@
     </div>
     {/if}
 </div>
+
+{#if showInfo && description}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="info-popover"
+        style={popoverStyle}
+        onmouseenter={() => clearTimeout(hideTimeout)}
+        onmouseleave={handleMouseLeave}
+        transition:scale={{duration: 150, start: 0.95}}
+    >
+        {description}
+    </div>
+{/if}
 
 
 <style>
@@ -32,6 +95,9 @@
 .setting-name {
     /* font-weight: 500; */
     font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .setting {
@@ -43,5 +109,38 @@
 .note {
     color: var(--font-color-muted);
     font-size: 0.9rem;
+}
+
+.info-btn {
+    color: var(--font-color-muted);
+    cursor: help;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.15s;
+}
+
+.info-btn:hover {
+    color: var(--font-color-accent);
+}
+
+.info-popover {
+    position: fixed;
+    z-index: 100;
+    width: 320px;
+    border-radius: var(--radius-level-2);
+    background: rgba(from var(--bg-level-1) r g b / 0.85);
+    backdrop-filter: blur(20px);
+    color: var(--font-color);
+    padding: 12px;
+    border: 1px solid var(--border-level-1);
+    box-shadow:
+        0 0 20px -1px rgba(0, 0, 0, 0.7),
+        0 0 1px white inset;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    white-space: pre-line;
+    transform-origin: top left;
+    pointer-events: auto;
 }
 </style>

--- a/src/lib/utils/schema.ts
+++ b/src/lib/utils/schema.ts
@@ -1,0 +1,28 @@
+import ghosttySchema from "$lib/data/ghostty-schema";
+
+/**
+ * Converts a camelCase setting ID to the kebab-case key used in ghostty-schema.
+ *
+ * Examples:
+ *   gtkOpenglDebug        -> gtk-opengl-debug
+ *   focusFollowsMouse     -> focus-follows-mouse
+ *   clipboardRead         -> clipboard-read
+ *   macosNonNativeFullscreen -> macos-non-native-fullscreen
+ *   x11InstanceName       -> x11-instance-name
+ */
+export function camelToKebab(id: string): string {
+    return id
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+        .toLowerCase();
+}
+
+/**
+ * Looks up the description for a setting by its camelCase ID.
+ * Returns undefined if the setting is not found in the schema.
+ */
+export function getSettingDescription(id: string): string | undefined {
+    const key = camelToKebab(id);
+    const def = ghosttySchema.find((s) => s.key === key);
+    return def?.description;
+}

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -53,7 +53,7 @@
                 {/if}
                 {#each group.settings as setting, i (setting.id)}
                     {#if i !== 0}<Separator />{/if}
-                    <Item name={setting.name} note={setting.note}>
+                    <Item name={setting.name} note={setting.note} settingId={setting.id}>
                         {#if setting.type === "switch"}
                             <Switch bind:checked={config[setting.id as keyof typeof config] as boolean} />
                         {:else if setting.type === "text"}


### PR DESCRIPTION
Adds contextual info popovers to each setting item, displaying the full Ghostty documentation description on hover. This gives users quick access to what each setting does without leaving the app.

## Demo

Each setting with a known description gets a small `ⓘ` icon next to its name. Hovering over it shows a positioned popover with the full description from the Ghostty schema.

## How it works

| Concern | Implementation |
|---|---|
| **Description lookup** | `getSettingDescription(id)` maps camelCase setting IDs → kebab-case schema keys |
| **Data source** | Existing `ghostty-schema.ts` (auto-generated from Ghostty's `Config.zig`) |
| **Trigger** | Mouse enter/leave with 150ms debounced hide (prevents flicker when moving to popover) |
| **Positioning** | Fixed positioning based on icon's `getBoundingClientRect()`, clamped to viewport |
| **Animation** | Svelte `scale` transition (150ms, starts at 0.95) for smooth appear/disappear |

## Changes

### `src/lib/utils/schema.ts` *(new)*
- **`camelToKebab(id)`** — converts camelCase setting IDs to kebab-case keys for schema lookup, handling edge cases like `x11InstanceName` → `x11-instance-name` and consecutive capitals
- **`getSettingDescription(id)`** — looks up a setting's description in the Ghostty schema by ID

### `src/lib/components/settings/Item.svelte`
- Accepts new optional `settingId` prop
- Renders an info icon (`ⓘ` SVG) next to the setting name when a description is available
- Shows a fixed-position popover on hover with the full description
- Popover stays visible when hovering over it (for readability), dismisses with 150ms delay
- Viewport-aware positioning prevents popover from overflowing the right edge
- Styled with frosted glass effect (`backdrop-filter: blur`) matching the app's aesthetic

### `src/routes/settings/[category]/+page.svelte`
- Passes `settingId={setting.id}` to each `<Item>` component

## Design decisions

- **No click required**: Hover-based interaction is consistent with native macOS tooltip patterns (matching the app's macOS System Preferences aesthetic)
- **Graceful degradation**: Settings without a schema description simply don't show the icon — no empty popovers
- **150ms hide delay**: Prevents the popover from flickering when the user moves their mouse from the icon to the popover content
- **Fixed positioning**: Avoids layout shifts and overflow issues within scrollable settings panels