### PR TITLE
Add persistent config state and setting description popovers

### DIFF
--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,12 +1,62 @@
 <script lang="ts">
     import type {Snippet} from "svelte";
+    import {scale} from "svelte/transition";
+    import {getSettingDescription} from "$lib/utils/schema";
 
-    const {name = "", note = "", children}: {name?: string, note?: string, children: Snippet} = $props();
+    const {name = "", note = "", settingId = "", children}: {name?: string, note?: string, settingId?: string, children: Snippet} = $props();
+
+    const description = $derived(settingId ? getSettingDescription(settingId) : undefined);
+
+    let showInfo = $state(false);
+    let hideTimeout: ReturnType<typeof setTimeout> | undefined;
+    let iconEl: HTMLSpanElement | undefined = $state();
+    let popoverStyle = $state("");
+
+    function updatePosition() {
+        if (!iconEl) return;
+        const rect = iconEl.getBoundingClientRect();
+        const popoverWidth = 320;
+
+        let left = rect.left;
+        if (left + popoverWidth > window.innerWidth - 12) {
+            left = window.innerWidth - popoverWidth - 12;
+        }
+
+        popoverStyle = `top: ${rect.bottom + 8}px; left: ${left}px;`;
+    }
+
+    function handleMouseEnter() {
+        clearTimeout(hideTimeout);
+        updatePosition();
+        showInfo = true;
+    }
+
+    function handleMouseLeave() {
+        hideTimeout = setTimeout(() => { showInfo = false; }, 150);
+    }
 </script>
 
 <div class="setting-item">
     <div class="row">
-        {#if name}<div class="setting-name">{name}</div>{/if}
+        {#if name}
+            <div class="setting-name">
+                {name}
+                {#if description}
+                    <!-- svelte-ignore a11y_no_static_element_interactions -->
+                    <span
+                        class="info-btn"
+                        bind:this={iconEl}
+                        onmouseenter={handleMouseEnter}
+                        onmouseleave={handleMouseLeave}
+                        aria-label="More info about {name}"
+                    >
+                        <svg width="8" height="8" viewBox="0 0 16 16" fill="currentColor">
+                            <path d="M8 0a8 8 0 1 0 0 16A8 8 0 0 0 8 0zm1 12H7V7h2v5zM8 6a1 1 0 1 1 0-2 1 1 0 0 1 0 2z"/>
+                        </svg>
+                    </span>
+                {/if}
+            </div>
+        {/if}
         <div class="setting">{@render children()}</div>
     </div>
     {#if note}
@@ -15,6 +65,19 @@
     </div>
     {/if}
 </div>
+
+{#if showInfo && description}
+    <!-- svelte-ignore a11y_no_static_element_interactions -->
+    <div
+        class="info-popover"
+        style={popoverStyle}
+        onmouseenter={() => clearTimeout(hideTimeout)}
+        onmouseleave={handleMouseLeave}
+        transition:scale={{duration: 150, start: 0.95}}
+    >
+        {description}
+    </div>
+{/if}
 
 
 <style>
@@ -32,6 +95,9 @@
 .setting-name {
     /* font-weight: 500; */
     font-size: 1.1rem;
+    display: flex;
+    align-items: center;
+    gap: 4px;
 }
 
 .setting {
@@ -43,5 +109,38 @@
 .note {
     color: var(--font-color-muted);
     font-size: 0.9rem;
+}
+
+.info-btn {
+    color: var(--font-color-muted);
+    cursor: help;
+    line-height: 1;
+    display: inline-flex;
+    align-items: center;
+    transition: color 0.15s;
+}
+
+.info-btn:hover {
+    color: var(--font-color-accent);
+}
+
+.info-popover {
+    position: fixed;
+    z-index: 100;
+    width: 320px;
+    border-radius: var(--radius-level-2);
+    background: rgba(from var(--bg-level-1) r g b / 0.85);
+    backdrop-filter: blur(20px);
+    color: var(--font-color);
+    padding: 12px;
+    border: 1px solid var(--border-level-1);
+    box-shadow:
+        0 0 20px -1px rgba(0, 0, 0, 0.7),
+        0 0 1px white inset;
+    font-size: 0.85rem;
+    line-height: 1.5;
+    white-space: pre-line;
+    transform-origin: top left;
+    pointer-events: auto;
 }
 </style>

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -23,6 +23,45 @@ if (dev) {
 
 const config = $state(Object.assign({}, defaults));
 
+const STORAGE_KEY = "ghostty-config";
+
+function saveToStorage() {
+    const d = diff();
+    if (Object.keys(d).length === 0) {
+        localStorage.removeItem(STORAGE_KEY);
+    }
+    else {
+        localStorage.setItem(STORAGE_KEY, JSON.stringify(d));
+    }
+}
+
+function loadFromStorage() {
+    const saved = localStorage.getItem(STORAGE_KEY);
+    if (!saved) return;
+    try {
+        const parsed = JSON.parse(saved) as Partial<typeof config>;
+        // Convert kebab-case keys back to camelCase
+        const converted: Record<string, unknown> = {};
+        for (const key in parsed) {
+            const camelKey = key.replaceAll(/-([a-z])/g, (_, c: string) => c.toUpperCase());
+            converted[camelKey] = parsed[key as keyof typeof parsed];
+        }
+        load(converted as Partial<typeof config>);
+    }
+    catch {
+        // Ignore corrupt data
+    }
+}
+
+loadFromStorage();
+
+$effect.root(() => {
+    $effect(() => {
+        // Access config deeply to track all changes
+        JSON.stringify(config);
+        saveToStorage();
+    });
+});
 
 export function keyToConfig(key: string) {
     return key.replaceAll(/([A-Z])/g, "-$1").toLowerCase();

--- a/src/lib/utils/schema.ts
+++ b/src/lib/utils/schema.ts
@@ -1,0 +1,28 @@
+import ghosttySchema from "$lib/data/ghostty-schema";
+
+/**
+ * Converts a camelCase setting ID to the kebab-case key used in ghostty-schema.
+ *
+ * Examples:
+ *   gtkOpenglDebug        -> gtk-opengl-debug
+ *   focusFollowsMouse     -> focus-follows-mouse
+ *   clipboardRead         -> clipboard-read
+ *   macosNonNativeFullscreen -> macos-non-native-fullscreen
+ *   x11InstanceName       -> x11-instance-name
+ */
+export function camelToKebab(id: string): string {
+    return id
+        .replace(/([a-z0-9])([A-Z])/g, "$1-$2")
+        .replace(/([A-Z])([A-Z][a-z])/g, "$1-$2")
+        .toLowerCase();
+}
+
+/**
+ * Looks up the description for a setting by its camelCase ID.
+ * Returns undefined if the setting is not found in the schema.
+ */
+export function getSettingDescription(id: string): string | undefined {
+    const key = camelToKebab(id);
+    const def = ghosttySchema.find((s) => s.key === key);
+    return def?.description;
+}

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -53,7 +53,7 @@
                 {/if}
                 {#each group.settings as setting, i (setting.id)}
                     {#if i !== 0}<Separator />{/if}
-                    <Item name={setting.name} note={setting.note}>
+                    <Item name={setting.name} note={setting.note} settingId={setting.id}>
                         {#if setting.type === "switch"}
                             <Switch bind:checked={config[setting.id as keyof typeof config] as boolean} />
                         {:else if setting.type === "text"}


### PR DESCRIPTION
Persist application config to localStorage so user changes survive page refreshes and browser restarts. Uses the existing diff() function to only store values that differ from defaults, and the existing load() function to restore them on initialization. An $effect.root reactive scope auto-saves on every config change.

Also add info icon popovers to setting items that display the full Ghostty schema description on hover. Introduces a schema utility module (schema.ts) for looking up descriptions by setting ID, and updates the Item component with a hover-triggered popover UI.