### PR TITLE
Support repeatable font family settings

### DIFF
--- a/src/lib/components/settings/RepeatableText.svelte
+++ b/src/lib/components/settings/RepeatableText.svelte
@@ -1,0 +1,81 @@
+<script lang="ts">
+    import Text from "./Text.svelte";
+
+    interface Props {
+        value: string[];
+        placeholder?: string;
+    }
+
+    // eslint-disable-next-line prefer-const
+    let {value = $bindable(), placeholder = ""}: Props = $props();
+
+    const normalize = (entries: string[]) => {
+        const next = entries.filter((entry, index) => entry !== "" || index === entries.length - 1);
+        return next.length ? next : [""];
+    };
+
+    const update = (index: number, nextValue: string) => {
+        const next = [...value];
+        next[index] = nextValue;
+
+        if (index === next.length - 1 && nextValue !== "") {
+            next.push("");
+        }
+
+        value = normalize(next);
+    };
+
+    const remove = (index: number) => {
+        const next = value.filter((_, entryIndex) => entryIndex !== index);
+        value = normalize(next);
+    };
+
+    const handleChange = (index: number, event: Event) => {
+        update(index, (event.currentTarget as HTMLInputElement).value);
+    };
+</script>
+
+<div class="repeatable-text">
+    {#each value as entry, index (index)}
+        <div class="entry">
+            <Text
+                value={entry}
+                {placeholder}
+                change={(event: Event) => handleChange(index, event)}
+            />
+            {#if value.length > 1}
+                <button type="button" aria-label="Remove entry" onclick={() => remove(index)}>x</button>
+            {/if}
+        </div>
+    {/each}
+</div>
+
+<style>
+.repeatable-text {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-end;
+    gap: 6px;
+}
+
+.entry {
+    display: flex;
+    align-items: center;
+    gap: 6px;
+}
+
+button {
+    background: var(--bg-level-2);
+    border: 1px solid var(--border-input);
+    border-radius: var(--radius-level-5);
+    color: inherit;
+    cursor: pointer;
+    line-height: 1;
+    width: 22px;
+    height: 22px;
+}
+
+button:hover {
+    background: var(--bg-level-3);
+}
+</style>

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -29,8 +29,9 @@ interface Switch extends BaseSettingItem {
 
 interface Text extends BaseSettingItem {
     type: "text";
-    value: string;
+    value: string | string[];
     placeholder?: string;
+    repeatable?: boolean;
 }
 
 interface Number extends BaseSettingItem {
@@ -400,10 +401,10 @@ const settings = [
                 name: "Font Families",
                 note: "By default Ghostty embeds and uses JetBrainsMono Nerd Font so you don't need to install it on your system or set it in your configuration.",
                 settings: [
-                    {id: "fontFamily", name: "Main font family", type: "text", value: "", placeholder: "JetBrainsMono NF"},
-                    {id: "fontFamilyBold", name: "Font family for bold text", type: "text", value: ""},
-                    {id: "fontFamilyItalic", name: "Font family for italic text", type: "text", value: ""},
-                    {id: "fontFamilyBoldItalic", name: "Font family for bold italic text", type: "text", value: ""},
+                    {id: "fontFamily", name: "Main font family", type: "text", value: [""], placeholder: "JetBrainsMono NF", repeatable: true},
+                    {id: "fontFamilyBold", name: "Font family for bold text", type: "text", value: [""], repeatable: true},
+                    {id: "fontFamilyItalic", name: "Font family for italic text", type: "text", value: [""], repeatable: true},
+                    {id: "fontFamilyBoldItalic", name: "Font family for bold italic text", type: "text", value: [""], repeatable: true},
                     {id: "fontCodepointMap", name: "Unicode-specifc font mapping", note: "", type: "text", value: ""},
                 ]
             },

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -39,6 +39,10 @@ export function diff() {
             const toAdd = config[key].filter(c => !defaults[key].includes(c));
             if (toAdd.length) output[keyToConfig(key)] = toAdd;
         }
+        else if (Array.isArray(config[key]) && key !== "palette") {
+            const toAdd = config[key].filter(Boolean);
+            if (toAdd.length) output[keyToConfig(key)] = toAdd;
+        }
         else if (Array.isArray(config[key]) && key === "palette") {
             const toAdd = [];
             for (let p = 0; p < defaults[key].length; p++) {
@@ -58,9 +62,14 @@ export function diff() {
 export function load(conf: Partial<typeof config>) {
     for (const key in conf) {
         if (!(key in config)) continue;
-        if (key !== "keybind" && key !== "palette") {
+        const configKey = key as keyof typeof config;
+        if (Array.isArray(conf[configKey]) && key !== "keybind" && key !== "palette") {
             // @ts-expect-error doing this properly is hard
-            config[key as keyof typeof config] = conf[key as keyof typeof config]!;
+            config[configKey] = [...conf[configKey]];
+        }
+        else if (key !== "keybind" && key !== "palette") {
+            // @ts-expect-error doing this properly is hard
+            config[configKey] = conf[configKey];
         }
         else if (key === "keybind") {
             config.keybind = [...config.keybind, ...conf.keybind!];
@@ -120,10 +129,10 @@ export default config;
 interface DefaultConfig {
     palette: HexColor[];
     keybind: KeybindString[];
-    fontFamily: string;
-    fontFamilyBold: string;
-    fontFamilyItalic: string;
-    fontFamilyBoldItalic: string;
+    fontFamily: string[];
+    fontFamilyBold: string[];
+    fontFamilyItalic: string[];
+    fontFamilyBoldItalic: string[];
     fontStyle: string;
     fontStyleBold: string;
     fontStyleItalic: string;

--- a/src/lib/utils/parse.test.ts
+++ b/src/lib/utils/parse.test.ts
@@ -1,0 +1,10 @@
+import {describe, expect, it} from "vitest";
+import parse from "./parse";
+
+describe("parse", () => {
+    it("keeps repeatable font family entries", () => {
+        expect(parse("font-family = JetBrainsMono NF\nfont-family = Noto Color Emoji")).toMatchObject({
+            fontFamily: ["JetBrainsMono NF", "Noto Color Emoji"]
+        });
+    });
+});

--- a/src/lib/utils/parse.ts
+++ b/src/lib/utils/parse.ts
@@ -4,6 +4,7 @@ import type {HexColor} from "./colors";
 const re = /^\s*([a-z-]+)[\s]*=\s*(.*)\s*$/;
 
 const colors = ["background", "foreground", "cursor-color", "selection-background", "selection-foreground"];
+const repeatableStrings = ["font-family", "font-family-bold", "font-family-italic", "font-family-bold-italic"];
 
 export default function (configString: string) {
     const lines = configString.split("\n");
@@ -40,7 +41,11 @@ export default function (configString: string) {
                 newKey += split[s].substring(1);
             }
 
-            if (colors.includes(key) && value.length === 6 && !value.startsWith("#")) {
+            if (repeatableStrings.includes(key)) {
+                const current = results[newKey];
+                results[newKey] = Array.isArray(current) ? [...current, value] : [value];
+            }
+            else if (colors.includes(key) && value.length === 6 && !value.startsWith("#")) {
                 results[newKey] = `#${value}`;
             }
             else {
@@ -51,4 +56,3 @@ export default function (configString: string) {
 
     return results;
 };
-

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -47,7 +47,7 @@
 
         // TODO: consider honoring separate fonts for bold/italic and such in previews
         // Add font settings
-        add("font-family", config.fontFamily || "JetBrainsMono Nerd Font");
+        add("font-family", config.fontFamily.find(Boolean) || "JetBrainsMono Nerd Font");
         add("font-size", `${config.fontSize}px`);
 
         return str;

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -10,6 +10,7 @@
     import settings from "$lib/data/settings";
     import config from "$lib/stores/config.svelte";
     import Text from "$lib/components/settings/Text.svelte";
+    import RepeatableText from "$lib/components/settings/RepeatableText.svelte";
     import Number from "$lib/components/settings/Number.svelte";
     import Dropdown from "$lib/components/settings/Dropdown.svelte";
     import Color from "$lib/components/settings/Color.svelte";
@@ -56,6 +57,8 @@
                     <Item name={setting.name} note={setting.note}>
                         {#if setting.type === "switch"}
                             <Switch bind:checked={config[setting.id as keyof typeof config] as boolean} />
+                        {:else if setting.type === "text" && setting.repeatable}
+                            <RepeatableText bind:value={config[setting.id as keyof typeof config] as string[]} placeholder={setting.placeholder} />
                         {:else if setting.type === "text"}
                             <Text bind:value={config[setting.id as keyof typeof config] as string} placeholder={setting.placeholder} />
                         {:else if setting.type === "number"}


### PR DESCRIPTION
Summary
- Add a repeatable text input for settings that can appear multiple times.
- Preserve repeated `font-family` entries when importing and exporting config.
- Use the first configured font family for the preview.

Testing
- bun test src/lib/utils/parse.test.ts src/lib/utils/share.test.ts src/lib/utils/keybinds.test.ts
- bun run check
- bun run lint
- bun run build
- git diff --check

Fixes #17