### PR TITLE
Add setting metadata badges and detailed help info modals

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -6,6 +6,7 @@
       "name": "ghostty-config",
       "dependencies": {
         "@fontsource-variable/inter": "^5.2.8",
+        "marked": "^18.0.4",
       },
       "devDependencies": {
         "@sveltejs/adapter-auto": "^7.0.1",
@@ -365,6 +366,8 @@
     "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "magic-string": ["magic-string@0.30.21", "", { "dependencies": { "@jridgewell/sourcemap-codec": "^1.5.5" } }, "sha512-vd2F4YUyEXKGcLHoq+TEyCjxueSeHnFxyyjNp80yg0XV4vUhnDer/lvvlqM/arB5bXQN5K2/3oinyCRyx8T2CQ=="],
+
+    "marked": ["marked@18.0.4", "", { "bin": { "marked": "bin/marked.js" } }, "sha512-c/BTaKzg0G6ezQx97DAkYU7k0HM6ys0FqYeKBL6hlBByZwy+ycA1+f0vDdjMHKKeEjdgkx0GOv9Il6D+85cOqA=="],
 
     "minimatch": ["minimatch@10.2.2", "", { "dependencies": { "brace-expansion": "^5.0.2" } }, "sha512-+G4CpNBxa5MprY+04MbgOw1v7So6n5JY166pFi9KfYwT78fxScCeSNQSNzp6dpPSW2rONOps6Ocam1wFhCgoVw=="],
 

--- a/package.json
+++ b/package.json
@@ -40,6 +40,7 @@
     },
     "type": "module",
     "dependencies": {
-        "@fontsource-variable/inter": "^5.2.8"
+        "@fontsource-variable/inter": "^5.2.8",
+        "marked": "^18.0.4"
     }
 }

--- a/src/lib/components/Badge.svelte
+++ b/src/lib/components/Badge.svelte
@@ -1,0 +1,56 @@
+<script lang="ts">
+    import {createTooltipAttachment} from "$lib/attachments/tooltip";
+
+    interface Props {
+        type: "platform" | "version";
+        label: string;
+        tooltip: string;
+    }
+
+    const {type, label, tooltip}: Props = $props();
+
+    const tooltipAttachment = createTooltipAttachment(() => tooltip);
+</script>
+
+
+<span
+    class="badge"
+    class:platform={type === "platform"}
+    class:version={type === "version"}
+    role="img"
+    aria-label={label}
+    {@attach tooltipAttachment}
+>
+    {#if type === "platform"}
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+            <path d="M0 0h56v56H0z" fill="none" />
+            <path fill="currentColor" d="M6.086 43.293h14.672l-.633 4.313h-3.21c-1.079 0-1.993.89-1.993 1.992s.914 2.015 1.992 2.015h22.172c1.078 0 1.992-.914 1.992-2.015a2.006 2.006 0 0 0-1.992-1.992h-3.21l-.634-4.313h14.672c4.008 0 6.023-1.922 6.023-6.023V10.41c0-4.101-2.015-6.023-6.023-6.023H6.086C2.078 4.387.6 6.309.6 10.41v26.86c0 4.101 1.478 6.023 5.486 6.023M4.844 32.981c-.703 0-1.008-.282-1.008-1.008V10.48c0-1.665.727-2.32 2.32-2.32h43.688c1.617 0 2.32.655 2.32 2.32v21.492c0 .726-.305 1.008-1.008 1.008ZM28 40.973c-1.172 0-2.18-.985-2.18-2.18c0-1.148 1.008-2.156 2.18-2.156s2.18 1.008 2.18 2.156c0 1.195-1.008 2.18-2.18 2.18" />
+        </svg>
+    {/if}
+    {#if type === "version"}
+        <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+            <path d="M0 0h56v56H0z" fill="none" />
+            <path fill="currentColor" d="M26.113 51.215c3.352 3.351 6.797 3.398 10.243-.024L51.19 36.38c3.422-3.422 3.375-6.89.024-10.242L28.293 3.262c-1.758-1.758-2.742-1.875-5.227-1.875H14.16c-2.484 0-3.258.61-5.015 2.367l-5.391 5.39c-1.781 1.782-2.367 2.555-2.367 5.04v8.906c0 2.46.093 3.469 1.875 5.226Zm2.532-2.836L5.91 25.645c-.469-.47-.75-.961-.75-1.735v-9.89c0-.727.258-1.22.75-1.711l6.375-6.375c.516-.493.985-.774 1.735-.774h9.867c.797 0 1.265.305 1.758.774l22.734 22.71c1.664 1.665 1.71 3.47-.023 5.18L33.823 48.356c-1.71 1.734-3.515 1.71-5.18.023M16.902 20.137c1.828 0 3.211-1.43 3.211-3.211c0-1.805-1.383-3.211-3.21-3.211c-1.829 0-3.212 1.406-3.212 3.21c0 1.782 1.383 3.212 3.211 3.212" />
+        </svg>
+    {/if}
+</span>
+
+
+<style>
+.badge {
+    display: inline-flex;
+    align-items: center;
+    color: var(--font-color-muted);
+    cursor: help;
+    user-select: none;
+}
+
+/* TODO: rethink these colors */
+.badge.platform {
+    color: #6B8CFF;
+}
+
+.badge.version {
+    color: #F0A500;
+}
+</style>

--- a/src/lib/components/Tooltip.svelte
+++ b/src/lib/components/Tooltip.svelte
@@ -23,7 +23,7 @@
         border: 1px solid var(--border-level-1);
         box-shadow:
             0 0 20px -1px rgba(0,0,0,0.7),
-            -0.5px 0 1px white inset;
+            0px 0 1px white inset;
         position: relative;
         z-index: 1;
         transform-origin: center bottom;

--- a/src/lib/components/modals/ModalStack.svelte
+++ b/src/lib/components/modals/ModalStack.svelte
@@ -1,4 +1,5 @@
 <script lang="ts">
+    import {marked} from "marked";
     import AlertModal from "$lib/components/modals/AlertModal.svelte";
     import Button from "$lib/components/Button.svelte";
     import {
@@ -27,7 +28,8 @@
         onclose={dismissTopModal}
     >
         {#if activeModal.message}
-            <p>{activeModal.message}</p>
+            <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+            {@html marked.parse(activeModal.message)}
         {/if}
 
         {#snippet actions()}
@@ -43,7 +45,27 @@
 
 
 <style>
-p {
+:global(.alert-body p) {
     margin: 0;
+}
+
+:global(.alert-body ul) {
+    padding-left: 1rem;
+    text-align: left;
+}
+
+:global(.alert-body ul li + li) {
+    margin-top: 0.25rem;
+}
+
+:global(.alert-body code) {
+    padding: 2px 4px;
+    border-radius: var(--radius-level-4);
+    background: rgba(from var(--bg-level-2) r g b / 0.6);
+    backdrop-filter: blur(20px);
+    border: 1px solid var(--border-level-1);
+    box-shadow:
+        0 0 1px -1px rgba(0,0,0,0.7),
+        0 0 1px white inset;
 }
 </style>

--- a/src/lib/components/settings/Group.svelte
+++ b/src/lib/components/settings/Group.svelte
@@ -15,7 +15,8 @@
 <div class="setting-group" class:borderless style:flex={flex ? flex : ""}>
     <div class="group-info">
         {#if title}<h2>{title}</h2>{/if}
-        {#if note}<h4>{note}</h4>{/if}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {#if note}<h4>{@html note}</h4>{/if}
     </div>
     <div class="settings-items" style:flex style:height={flex ? "100%" : null}>
         {@render children()}
@@ -51,6 +52,17 @@ h4 {
     color: var(--font-color-muted);
     margin-top: -6px;
     white-space: preserve;
+}
+
+h4 :global(code) {
+    padding: 2px 4px;
+    border-radius: var(--radius-level-4);
+    background: rgba(from var(--bg-level-2) r g b / 0.6);
+    backdrop-filter: blur(20px);
+    border: 1px solid var(--border-level-1);
+    box-shadow:
+        0 0 1px -1px rgba(0,0,0,0.7),
+        0 0 1px white inset;
 }
 
 .settings-items {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -2,6 +2,7 @@
     import {onMount, type Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
+    import {alert} from "$lib/stores/modals.svelte";
 
     interface Props {
         name?: string;
@@ -60,11 +61,11 @@
         return `${labels[0]} +${labels.length - 1}`;
     };
 
-    const parseVersion = (version: string) =>
-        version
-            .split(".")
-            .map((part) => Number.parseInt(part, 10))
-            .map((num) => Number.isFinite(num) ? num : 0);
+    // const parseVersion = (version: string) =>
+    //     version
+    //         .split(".")
+    //         .map((part) => Number.parseInt(part, 10))
+    //         .map((num) => Number.isFinite(num) ? num : 0);
 
     const isSinceVisible = $derived.by(() => {
         // if (!since) return false;
@@ -114,15 +115,12 @@
             tooltipAttachment: createTooltipAttachment(() => getBadgeTooltip(badge))
         }))
     );
-
-    const schemaDescriptionTooltip = $derived(schemaDescription || "");
-    const schemaDescriptionAttachment = createTooltipAttachment(() => schemaDescriptionTooltip);
 </script>
 
 <div class="setting-item">
     <div class="row">
         {#if name}
-        <div class="setting-name-wrapper">
+        <div class="row-left">
             <div class="setting-name">{name}</div>
             {#if metadataBadgesWithTooltips.length > 0 || schemaDescription}
                 <div class="metadata" aria-label="Setting metadata">
@@ -136,9 +134,6 @@
                             {@attach badge.tooltipAttachment}
                         >{badge.label}</span>
                     {/each}
-                    {#if schemaDescription}
-                        <button type="button" class="metadata-info" aria-label="Full description" {@attach schemaDescriptionAttachment}>i</button>
-                    {/if}
                 </div>
             {/if}
             {#if isNonDefault && onReset}
@@ -159,7 +154,18 @@
             {/if}
         </div>
         {/if}
-        <div class="setting">{@render children()}</div>
+        <div class="row-right">
+            <div class="setting">{@render children()}</div>
+            {#if schemaDescription}
+                <button type="button" class="setting-info" aria-label="Full description" onclick={() => alert({title: name, message: schemaDescription})}>
+                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                        <circle cx="12" cy="12" r="10" />
+                        <path d="M12 16v-4" />
+                        <path d="M12 8h.01" />
+                    </svg>
+                </button>
+            {/if}
+        </div>
     </div>
     {#if note}
     <div class="note">
@@ -182,7 +188,7 @@
     align-items: flex-start;
 }
 
-.setting-name-wrapper {
+.row-left {
     display: flex;
     align-items: center;
     gap: 6px;
@@ -225,24 +231,26 @@
     background: color-mix(in srgb, var(--color-input-accent) 12%, transparent);
 }
 
-.metadata-info {
+.setting-info {
     display: inline-flex;
     align-items: center;
     justify-content: center;
     width: 16px;
     height: 16px;
-    border-radius: 50%;
-    border: 1px solid var(--border-level-3);
-    background: color-mix(in srgb, var(--bg-level-3) 90%, transparent);
+    border: 0;
+    padding: 0;
+    background: none;
     color: var(--font-color-muted);
-    font-size: 0.65rem;
-    font-weight: 700;
-    cursor: help;
-    user-select: none;
+    cursor: pointer;
 }
 
-.metadata-info:focus-visible,
-.metadata-info:hover {
+.setting-info svg {
+    width: 16px;
+    height: 16px;
+}
+
+.setting-info:focus-visible,
+.setting-info:hover {
     border-color: var(--color-input-accent);
     color: var(--font-color);
     outline: none;
@@ -287,10 +295,17 @@
     stroke-width: 2.5;
 }
 
-.setting {
+.row-right {
     display: flex;
+    align-items: center;
     flex: 1;
     justify-content: flex-end;
+    gap: 10px;
+}
+
+.row-right,
+.setting {
+    display: flex;
 }
 
 .note {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -23,37 +23,37 @@
         "macos": "macOS",
         "linux": "Linux",
         "gtk": "GTK",
-        "gtk-wayland": "GTK Wayland",
-        "gtk-x11": "GTK X11"
+        "gtk-wayland": "GTK (Wayland)",
+        "gtk-x11": "GTK (X11)"
     };
 
     const platformLabels = $derived(
         platform?.map((value) => platformLabelMap[value]).filter(Boolean) ?? []
     );
 
-        type RuntimePlatform = "macos" | "linux" | "other";
+    // type RuntimePlatform = "macos" | "linux" | "other";
 
-    let runtimePlatform = $state<RuntimePlatform>("other");
+    // let runtimePlatform = $state<RuntimePlatform>("other");
 
-    onMount(() => {
-        const userAgent = navigator.userAgent.toLowerCase();
-        if (userAgent.includes("mac")) runtimePlatform = "macos";
-        else if (userAgent.includes("linux")) runtimePlatform = "linux";
-        else runtimePlatform = "other";
-    });
+    // onMount(() => {
+    //     const userAgent = navigator.userAgent.toLowerCase();
+    //     if (userAgent.includes("mac")) runtimePlatform = "macos";
+    //     else if (userAgent.includes("linux")) runtimePlatform = "linux";
+    //     else runtimePlatform = "other";
+    // });
 
-    const supportedPlatformsByRuntime: Record<RuntimePlatform, GhosttyPlatform[]> = {
-        macos: ["macos"],
-        linux: ["linux", "gtk", "gtk-wayland", "gtk-x11"],
-        other: []
-    };
+    // const supportedPlatformsByRuntime: Record<RuntimePlatform, GhosttyPlatform[]> = {
+    //     macos: ["macos"],
+    //     linux: ["linux", "gtk", "gtk-wayland", "gtk-x11"],
+    //     other: []
+    // };
 
-    const isUnsupportedOnCurrentOS = $derived.by(() => {
-        if (!platform || platform.length === 0) return false;
-        if (runtimePlatform === "other") return true;
-        const supported = supportedPlatformsByRuntime[runtimePlatform];
-        return !platform.some((value) => supported.includes(value));
-    });
+    // const isUnsupportedOnCurrentOS = $derived.by(() => {
+    //     if (!platform || platform.length === 0) return false;
+    //     if (runtimePlatform === "other") return true;
+    //     const supported = supportedPlatformsByRuntime[runtimePlatform];
+    //     return !platform.some((value) => supported.includes(value));
+    // });
 
     const getPlatformBadgeLabel = (labels: string[]) => {
         if (labels.length === 0) return "";
@@ -88,10 +88,10 @@
 
     const metadataBadges = $derived.by(() => {
         const badges: Array<{label: string, type: "unsupported" | "platform" | "version"}> = [];
-        if (isUnsupportedOnCurrentOS) badges.push({label: "Not available on this OS", type: "unsupported"});
+        // if (isUnsupportedOnCurrentOS) badges.push({label: "Not available on this OS", type: "unsupported"});
         const platformBadge = getPlatformBadgeLabel(platformLabels);
         if (platformBadge) badges.push({label: platformBadge, type: "platform"});
-        if (isSinceVisible) badges.push({label: `New in ${since}`, type: "version"});
+        if (isSinceVisible && since) badges.push({label: since, type: "version"});
         return badges;
     });
 
@@ -102,7 +102,7 @@
             case "platform":
                 return platformLabels.length > 1 ? `Available on: ${platformLabels.join(", ")}` : `Platform: ${platformLabels[0]}`;
             case "version":
-                return `Introduced in Ghostty ${since}`;
+                return `Added in Ghostty v${since}`;
             default:
                 return "";
         }
@@ -122,17 +122,37 @@
         {#if name}
         <div class="row-left">
             <div class="setting-name">{name}</div>
-            {#if metadataBadgesWithTooltips.length > 0 || schemaDescription}
+            {#if metadataBadgesWithTooltips.length > 0}
                 <div class="metadata" aria-label="Setting metadata">
                     {#each metadataBadgesWithTooltips as badge (badge.key)}
                         <span
                             class="metadata-badge"
-                            class:warning={badge.type === "unsupported"}
+                            class:warning={badge.type === "platform"}
                             class:version={badge.type === "version"}
                             role="img"
                             aria-label={badge.label}
                             {@attach badge.tooltipAttachment}
-                        >{badge.label}</span>
+                        >
+                        {#if badge.type === "platform"}
+                            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                                <path d="M0 0h56v56H0z" fill="none" />
+                                <path fill="currentColor" d="M6.086 43.293h14.672l-.633 4.313h-3.21c-1.079 0-1.993.89-1.993 1.992s.914 2.015 1.992 2.015h22.172c1.078 0 1.992-.914 1.992-2.015a2.006 2.006 0 0 0-1.992-1.992h-3.21l-.634-4.313h14.672c4.008 0 6.023-1.922 6.023-6.023V10.41c0-4.101-2.015-6.023-6.023-6.023H6.086C2.078 4.387.6 6.309.6 10.41v26.86c0 4.101 1.478 6.023 5.486 6.023M4.844 32.981c-.703 0-1.008-.282-1.008-1.008V10.48c0-1.665.727-2.32 2.32-2.32h43.688c1.617 0 2.32.655 2.32 2.32v21.492c0 .726-.305 1.008-1.008 1.008ZM28 40.973c-1.172 0-2.18-.985-2.18-2.18c0-1.148 1.008-2.156 2.18-2.156s2.18 1.008 2.18 2.156c0 1.195-1.008 2.18-2.18 2.18" />
+                            </svg>
+                        {/if}
+                        {#if badge.type === "version"}
+                        <!-- <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                            <path d="M0 0h56v56H0z" fill="none" />
+                            <path fill="currentColor" d="M26.688 12.66c.28 0 .421-.164.492-.422c.726-3.914.68-4.008 4.758-4.781c.28-.047.445-.21.445-.492c0-.281-.164-.445-.446-.492c-4.054-.82-3.937-.914-4.757-4.782c-.07-.257-.211-.421-.492-.421s-.422.164-.493.421c-.82 3.868-.68 3.961-4.757 4.782c-.258.046-.446.21-.446.492c0 .281.188.445.445.492c4.079.82 4.032.867 4.758 4.781c.07.258.211.422.492.422M15.344 28.785c.445 0 .75-.281.797-.703c.843-6.258 1.054-6.258 7.523-7.5c.422-.07.727-.352.727-.797c0-.422-.305-.726-.727-.797c-6.469-.89-6.703-1.101-7.523-7.476c-.047-.422-.352-.727-.797-.727c-.422 0-.727.305-.774.75c-.773 6.281-1.101 6.258-7.523 7.453c-.422.094-.727.375-.727.797c0 .469.305.727.82.797c6.376 1.031 6.657 1.195 7.43 7.453c.047.469.352.75.774.75m15.89 25.946c.61 0 1.055-.446 1.172-1.079c1.664-12.843 3.469-14.789 16.172-16.195c.656-.07 1.102-.562 1.102-1.172s-.446-1.078-1.102-1.172c-12.703-1.406-14.508-3.351-16.172-16.195c-.117-.633-.562-1.055-1.172-1.055s-1.054.422-1.148 1.055c-1.664 12.844-3.492 14.789-16.172 16.195c-.68.094-1.125.563-1.125 1.172c0 .61.445 1.102 1.125 1.172c12.656 1.664 14.414 3.375 16.172 16.195c.094.633.539 1.078 1.148 1.078" />
+                        </svg> -->
+
+                            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                                <path d="M0 0h56v56H0z" fill="none" />
+                                <path fill="currentColor" d="M26.113 51.215c3.352 3.351 6.797 3.398 10.243-.024L51.19 36.38c3.422-3.422 3.375-6.89.024-10.242L28.293 3.262c-1.758-1.758-2.742-1.875-5.227-1.875H14.16c-2.484 0-3.258.61-5.015 2.367l-5.391 5.39c-1.781 1.782-2.367 2.555-2.367 5.04v8.906c0 2.46.093 3.469 1.875 5.226Zm2.532-2.836L5.91 25.645c-.469-.47-.75-.961-.75-1.735v-9.89c0-.727.258-1.22.75-1.711l6.375-6.375c.516-.493.985-.774 1.735-.774h9.867c.797 0 1.265.305 1.758.774l22.734 22.71c1.664 1.665 1.71 3.47-.023 5.18L33.823 48.356c-1.71 1.734-3.515 1.71-5.18.023M16.902 20.137c1.828 0 3.211-1.43 3.211-3.211c0-1.805-1.383-3.211-3.21-3.211c-1.829 0-3.212 1.406-3.212 3.21c0 1.782 1.383 3.212 3.211 3.212" />
+                            </svg>
+
+
+                        {/if}
+                    </span>
                     {/each}
                 </div>
             {/if}
@@ -154,18 +174,24 @@
             {/if}
         </div>
         {/if}
-        <div class="row-right">
-            <div class="setting">{@render children()}</div>
-            {#if schemaDescription}
+        {#if schemaDescription}
+            <div class="row-right">
+                <div class="setting">{@render children()}</div>
                 <button type="button" class="setting-info" aria-label="Full description" onclick={() => alert({title: name, message: schemaDescription})}>
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                    <!-- <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
                         <circle cx="12" cy="12" r="10" />
                         <path d="M12 16v-4" />
                         <path d="M12 8h.01" />
+                    </svg> -->
+                    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                        <path d="M0 0h56v56H0z" fill="none" />
+                        <path fill="currentColor" d="M28 51.906c13.055 0 23.906-10.828 23.906-23.906c0-13.055-10.875-23.906-23.93-23.906C14.899 4.094 4.095 14.945 4.095 28c0 13.078 10.828 23.906 23.906 23.906m0-3.984C16.937 47.922 8.1 39.062 8.1 28c0-11.04 8.813-19.922 19.876-19.922c11.039 0 19.921 8.883 19.945 19.922c.023 11.063-8.883 19.922-19.922 19.922m-.211-28.266c1.71 0 3.047-1.36 3.047-3.047c0-1.71-1.336-3.07-3.047-3.07s-3.047 1.36-3.047 3.07a3.026 3.026 0 0 0 3.047 3.047m-3.914 21.235h9.562c.961 0 1.711-.68 1.711-1.641c0-.914-.75-1.64-1.71-1.64H30.53V25.68c0-1.266-.656-2.11-1.828-2.11h-4.43c-.937 0-1.687.727-1.687 1.64c0 .962.75 1.642 1.687 1.642h2.532v10.757h-2.93c-.938 0-1.688.727-1.688 1.641c0 .96.75 1.64 1.688 1.64" />
                     </svg>
                 </button>
-            {/if}
-        </div>
+            </div>
+        {:else}
+            <div class="setting">{@render children()}</div>
+        {/if}
     </div>
     {#if note}
     <div class="note">
@@ -207,28 +233,34 @@
 .metadata-badge {
     display: inline-flex;
     align-items: center;
-    border-radius: 999px;
-    border: 1px solid var(--border-level-3);
-    background: color-mix(in srgb, var(--bg-level-3) 92%, transparent);
+    /* border-radius: 999px; */
+    /* border: 1px solid var(--border-level-3); */
+    /* background: color-mix(in srgb, var(--bg-level-3) 92%, transparent); */
     color: var(--font-color-muted);
-    font-size: 0.68rem;
-    font-weight: 600;
-    letter-spacing: 0.01em;
-    line-height: 1;
-    padding: 3px 7px;
-    cursor: default;
+    /* font-size: 0.68rem; */
+    /* font-weight: 600; */
+    /* letter-spacing: 0.01em; */
+    /* line-height: 1; */
+    /* padding: 3px 7px; */
+    /* cursor: default; */
+    cursor: help;
+    user-select: none;
 }
 
 .metadata-badge.warning {
-    color: #f8dca4;
-    border-color: color-mix(in srgb, var(--color-warning) 65%, #000);
-    background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+    /* color: #f8dca4; */
+    /* border-color: color-mix(in srgb, var(--color-warning) 65%, #000); */
+    /* background: color-mix(in srgb, var(--color-warning) 18%, transparent); */
+    color: var(--color-input-accent);
+    color: #6B8CFF;
 }
 
 .metadata-badge.version {
-    color: color-mix(in srgb, var(--color-input-accent) 90%, #fff);
-    border-color: color-mix(in srgb, var(--color-input-accent) 45%, transparent);
-    background: color-mix(in srgb, var(--color-input-accent) 12%, transparent);
+    /* color: color-mix(in srgb, var(--color-input-accent) 90%, #fff); */
+    /* border-color: color-mix(in srgb, var(--color-input-accent) 45%, transparent); */
+    /* background: color-mix(in srgb, var(--color-input-accent) 12%, transparent); */
+    color: #f8dca4;
+    color: #F0A500;
 }
 
 .setting-info {
@@ -303,9 +335,13 @@
     gap: 10px;
 }
 
-.row-right,
 .setting {
     display: flex;
+    flex: 1;
+}
+
+.row-right .setting {
+    flex: none;
 }
 
 .note {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {onMount, type Snippet} from "svelte";
+    import {type Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
     import {alert} from "$lib/stores/modals.svelte";
@@ -31,85 +31,28 @@
         platform?.map((value) => platformLabelMap[value]).filter(Boolean) ?? []
     );
 
-    // type RuntimePlatform = "macos" | "linux" | "other";
-
-    // let runtimePlatform = $state<RuntimePlatform>("other");
-
-    // onMount(() => {
-    //     const userAgent = navigator.userAgent.toLowerCase();
-    //     if (userAgent.includes("mac")) runtimePlatform = "macos";
-    //     else if (userAgent.includes("linux")) runtimePlatform = "linux";
-    //     else runtimePlatform = "other";
-    // });
-
-    // const supportedPlatformsByRuntime: Record<RuntimePlatform, GhosttyPlatform[]> = {
-    //     macos: ["macos"],
-    //     linux: ["linux", "gtk", "gtk-wayland", "gtk-x11"],
-    //     other: []
-    // };
-
-    // const isUnsupportedOnCurrentOS = $derived.by(() => {
-    //     if (!platform || platform.length === 0) return false;
-    //     if (runtimePlatform === "other") return true;
-    //     const supported = supportedPlatformsByRuntime[runtimePlatform];
-    //     return !platform.some((value) => supported.includes(value));
-    // });
-
     const getPlatformBadgeLabel = (labels: string[]) => {
         if (labels.length === 0) return "";
         if (labels.length === 1) return labels[0];
         return `${labels[0]} +${labels.length - 1}`;
     };
 
-    // const parseVersion = (version: string) =>
-    //     version
-    //         .split(".")
-    //         .map((part) => Number.parseInt(part, 10))
-    //         .map((num) => Number.isFinite(num) ? num : 0);
-
-    const isSinceVisible = $derived.by(() => {
-        // if (!since) return false;
-        // if (!versionBaseline) return true;
-
-        // const settingParts = parseVersion(since);
-        // const baselineParts = parseVersion(versionBaseline);
-        // const maxLen = Math.max(settingParts.length, baselineParts.length);
-
-        // for (let i = 0; i < maxLen; i++) {
-        //     const settingNum = settingParts[i] ?? 0;
-        //     const baselineNum = baselineParts[i] ?? 0;
-        //     if (settingNum > baselineNum) return true;
-        //     if (settingNum < baselineNum) return false;
-        // }
-
-        // return false;
-        return !!since;
-    });
-
-    const metadataBadges = $derived.by(() => {
-        const badges: Array<{label: string, type: "unsupported" | "platform" | "version"}> = [];
-        // if (isUnsupportedOnCurrentOS) badges.push({label: "Not available on this OS", type: "unsupported"});
+    const infoBadges = $derived.by(() => {
+        const badges: Array<{label: string, type: "platform" | "version"}> = [];
         const platformBadge = getPlatformBadgeLabel(platformLabels);
         if (platformBadge) badges.push({label: platformBadge, type: "platform"});
-        if (isSinceVisible && since) badges.push({label: since, type: "version"});
+        if (since) badges.push({label: since, type: "version"});
         return badges;
     });
 
-    const getBadgeTooltip = (badge: {label: string, type: "unsupported" | "platform" | "version"}) => {
-        switch (badge.type) {
-            case "unsupported":
-                return "Not available on your current operating system";
-            case "platform":
-                return platformLabels.length > 1 ? `Available on: ${platformLabels.join(", ")}` : `Platform: ${platformLabels[0]}`;
-            case "version":
-                return `Added in Ghostty v${since}`;
-            default:
-                return "";
-        }
+    const getBadgeTooltip = (badge: {label: string, type: "platform" | "version"}) => {
+        if (badge.type === "platform") return platformLabels.length > 1 ? `Available on: ${platformLabels.join(", ")}` : `Platform: ${platformLabels[0]}`;
+        if (badge.type === "version") return `Added in Ghostty v${since}`;
+        return "";
     };
 
-    const metadataBadgesWithTooltips = $derived.by(() =>
-        metadataBadges.map((badge) => ({
+    const infoBadgesWithTooltips = $derived.by(() =>
+        infoBadges.map((badge) => ({
             ...badge,
             key: `${badge.type}-${badge.label}`,
             tooltipAttachment: createTooltipAttachment(() => getBadgeTooltip(badge))
@@ -122,12 +65,12 @@
         {#if name}
         <div class="row-left">
             <div class="setting-name">{name}</div>
-            {#if metadataBadgesWithTooltips.length > 0}
-                <div class="metadata" aria-label="Setting metadata">
-                    {#each metadataBadgesWithTooltips as badge (badge.key)}
+            {#if infoBadgesWithTooltips.length > 0 || (isNonDefault && onReset)}
+                <div class="setting-extra">
+                    {#each infoBadgesWithTooltips as badge (badge.key)}
                         <span
-                            class="metadata-badge"
-                            class:warning={badge.type === "platform"}
+                            class="badge"
+                            class:platform={badge.type === "platform"}
                             class:version={badge.type === "version"}
                             role="img"
                             aria-label={badge.label}
@@ -154,23 +97,29 @@
                         {/if}
                     </span>
                     {/each}
+
+                    {#if isNonDefault && onReset}
+                    <!-- <div class="reset-button-wrapper"> -->
+                        <button
+                            class="reset-button"
+                            onclick={onReset}
+                            title="Reset to default"
+                            type="button"
+                            {@attach tooltipAttachment}
+                        >
+                            <!-- <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+                                <path d="M9 14 4 9l5-5" />
+                                <path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11" />
+                            </svg> -->
+                            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                                <path d="M0 0h56v56H0z" fill="none" />
+                                <path fill="currentColor" stroke="currentColor" stroke-width="2.5" paint-order="stroke" d="M50.148 34.914c0-8.953-6.046-15.14-16.757-15.14H17.664l-5.508.257l4.454-3.797l6.75-6.609c.374-.375.562-.82.562-1.43c0-1.218-.82-2.062-2.062-2.062c-.516 0-1.126.258-1.524.656L6.555 20.312c-.469.446-.703.985-.703 1.57c0 .563.234 1.102.703 1.548l13.781 13.523a2.2 2.2 0 0 0 1.524.656c1.242 0 2.062-.843 2.062-2.062c0-.61-.188-1.055-.562-1.43l-6.75-6.586l-4.454-3.797l5.508.235h16.078c7.992 0 12.235 4.406 12.235 10.71c0 6.329-4.243 11.016-12.235 11.016h-5.39c-1.29 0-2.133.938-2.133 2.086c0 1.149.844 2.086 2.133 2.086h5.414c10.5 0 16.382-5.976 16.382-14.953" />
+                            </svg>
+
+                        </button>
+                    <!-- </div> -->
+                    {/if}
                 </div>
-            {/if}
-            {#if isNonDefault && onReset}
-            <div class="reset-button-wrapper">
-                <button
-                    class="reset-button"
-                    onclick={onReset}
-                    title="Reset to default"
-                    type="button"
-                    {@attach tooltipAttachment}
-                >
-                    <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <path d="M9 14 4 9l5-5" />
-                        <path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11" />
-                    </svg>
-                </button>
-            </div>
             {/if}
         </div>
         {/if}
@@ -218,19 +167,20 @@
     display: flex;
     align-items: center;
     gap: 6px;
+    flex-wrap: wrap;
 }
 
 .setting-name {
     font-weight: 500;
 }
 
-.metadata {
+.setting-extra {
     display: inline-flex;
     align-items: center;
     gap: 5px;
 }
 
-.metadata-badge {
+.badge {
     display: inline-flex;
     align-items: center;
     /* border-radius: 999px; */
@@ -247,19 +197,19 @@
     user-select: none;
 }
 
-.metadata-badge.warning {
+.badge.platform {
     /* color: #f8dca4; */
-    /* border-color: color-mix(in srgb, var(--color-warning) 65%, #000); */
-    /* background: color-mix(in srgb, var(--color-warning) 18%, transparent); */
-    color: var(--color-input-accent);
+    /* border-color: color-mix(in srgb, var(--color-platform) 65%, #000); */
+    /* background: color-mix(in srgb, var(--color-platform) 18%, transparent); */
+    /* color: var(--color-input-accent); */
     color: #6B8CFF;
 }
 
-.metadata-badge.version {
+.badge.version {
     /* color: color-mix(in srgb, var(--color-input-accent) 90%, #fff); */
     /* border-color: color-mix(in srgb, var(--color-input-accent) 45%, transparent); */
     /* background: color-mix(in srgb, var(--color-input-accent) 12%, transparent); */
-    color: #f8dca4;
+    /* color: #f8dca4; */
     color: #F0A500;
 }
 
@@ -288,16 +238,10 @@
     outline: none;
 }
 
-.reset-button-wrapper {
-    position: relative;
-    display: flex;
-    align-items: center;
-}
-
 .reset-button {
     background: none;
-    border: none;
-    /* padding: 4px; */
+    border: 0;
+    padding: 0;
     cursor: pointer;
     display: flex;
     align-items: center;
@@ -324,7 +268,6 @@
 .reset-button svg {
     width: 14px;
     height: 14px;
-    stroke-width: 2.5;
 }
 
 .row-right {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -83,23 +83,15 @@
                             </svg>
                         {/if}
                         {#if badge.type === "version"}
-                        <!-- <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
-                            <path d="M0 0h56v56H0z" fill="none" />
-                            <path fill="currentColor" d="M26.688 12.66c.28 0 .421-.164.492-.422c.726-3.914.68-4.008 4.758-4.781c.28-.047.445-.21.445-.492c0-.281-.164-.445-.446-.492c-4.054-.82-3.937-.914-4.757-4.782c-.07-.257-.211-.421-.492-.421s-.422.164-.493.421c-.82 3.868-.68 3.961-4.757 4.782c-.258.046-.446.21-.446.492c0 .281.188.445.445.492c4.079.82 4.032.867 4.758 4.781c.07.258.211.422.492.422M15.344 28.785c.445 0 .75-.281.797-.703c.843-6.258 1.054-6.258 7.523-7.5c.422-.07.727-.352.727-.797c0-.422-.305-.726-.727-.797c-6.469-.89-6.703-1.101-7.523-7.476c-.047-.422-.352-.727-.797-.727c-.422 0-.727.305-.774.75c-.773 6.281-1.101 6.258-7.523 7.453c-.422.094-.727.375-.727.797c0 .469.305.727.82.797c6.376 1.031 6.657 1.195 7.43 7.453c.047.469.352.75.774.75m15.89 25.946c.61 0 1.055-.446 1.172-1.079c1.664-12.843 3.469-14.789 16.172-16.195c.656-.07 1.102-.562 1.102-1.172s-.446-1.078-1.102-1.172c-12.703-1.406-14.508-3.351-16.172-16.195c-.117-.633-.562-1.055-1.172-1.055s-1.054.422-1.148 1.055c-1.664 12.844-3.492 14.789-16.172 16.195c-.68.094-1.125.563-1.125 1.172c0 .61.445 1.102 1.125 1.172c12.656 1.664 14.414 3.375 16.172 16.195c.094.633.539 1.078 1.148 1.078" />
-                        </svg> -->
-
                             <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
                                 <path d="M0 0h56v56H0z" fill="none" />
                                 <path fill="currentColor" d="M26.113 51.215c3.352 3.351 6.797 3.398 10.243-.024L51.19 36.38c3.422-3.422 3.375-6.89.024-10.242L28.293 3.262c-1.758-1.758-2.742-1.875-5.227-1.875H14.16c-2.484 0-3.258.61-5.015 2.367l-5.391 5.39c-1.781 1.782-2.367 2.555-2.367 5.04v8.906c0 2.46.093 3.469 1.875 5.226Zm2.532-2.836L5.91 25.645c-.469-.47-.75-.961-.75-1.735v-9.89c0-.727.258-1.22.75-1.711l6.375-6.375c.516-.493.985-.774 1.735-.774h9.867c.797 0 1.265.305 1.758.774l22.734 22.71c1.664 1.665 1.71 3.47-.023 5.18L33.823 48.356c-1.71 1.734-3.515 1.71-5.18.023M16.902 20.137c1.828 0 3.211-1.43 3.211-3.211c0-1.805-1.383-3.211-3.21-3.211c-1.829 0-3.212 1.406-3.212 3.21c0 1.782 1.383 3.212 3.211 3.212" />
                             </svg>
-
-
                         {/if}
                     </span>
                     {/each}
 
                     {#if isNonDefault && onReset}
-                    <!-- <div class="reset-button-wrapper"> -->
                         <button
                             class="reset-button"
                             onclick={onReset}
@@ -107,17 +99,12 @@
                             type="button"
                             {@attach tooltipAttachment}
                         >
-                            <!-- <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                                <path d="M9 14 4 9l5-5" />
-                                <path d="M4 9h10.5a5.5 5.5 0 0 1 5.5 5.5a5.5 5.5 0 0 1-5.5 5.5H11" />
-                            </svg> -->
                             <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
                                 <path d="M0 0h56v56H0z" fill="none" />
                                 <path fill="currentColor" stroke="currentColor" stroke-width="2.5" paint-order="stroke" d="M50.148 34.914c0-8.953-6.046-15.14-16.757-15.14H17.664l-5.508.257l4.454-3.797l6.75-6.609c.374-.375.562-.82.562-1.43c0-1.218-.82-2.062-2.062-2.062c-.516 0-1.126.258-1.524.656L6.555 20.312c-.469.446-.703.985-.703 1.57c0 .563.234 1.102.703 1.548l13.781 13.523a2.2 2.2 0 0 0 1.524.656c1.242 0 2.062-.843 2.062-2.062c0-.61-.188-1.055-.562-1.43l-6.75-6.586l-4.454-3.797l5.508.235h16.078c7.992 0 12.235 4.406 12.235 10.71c0 6.329-4.243 11.016-12.235 11.016h-5.39c-1.29 0-2.133.938-2.133 2.086c0 1.149.844 2.086 2.133 2.086h5.414c10.5 0 16.382-5.976 16.382-14.953" />
                             </svg>
 
                         </button>
-                    <!-- </div> -->
                     {/if}
                 </div>
             {/if}
@@ -127,11 +114,6 @@
             <div class="row-right">
                 <div class="setting">{@render children()}</div>
                 <button type="button" class="setting-info" aria-label="Full description" onclick={() => alert({title: name, message: schemaDescription})}>
-                    <!-- <svg xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
-                        <circle cx="12" cy="12" r="10" />
-                        <path d="M12 16v-4" />
-                        <path d="M12 8h.01" />
-                    </svg> -->
                     <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
                         <path d="M0 0h56v56H0z" fill="none" />
                         <path fill="currentColor" d="M28 51.906c13.055 0 23.906-10.828 23.906-23.906c0-13.055-10.875-23.906-23.93-23.906C14.899 4.094 4.095 14.945 4.095 28c0 13.078 10.828 23.906 23.906 23.906m0-3.984C16.937 47.922 8.1 39.062 8.1 28c0-11.04 8.813-19.922 19.876-19.922c11.039 0 19.921 8.883 19.945 19.922c.023 11.063-8.883 19.922-19.922 19.922m-.211-28.266c1.71 0 3.047-1.36 3.047-3.047c0-1.71-1.336-3.07-3.047-3.07s-3.047 1.36-3.047 3.07a3.026 3.026 0 0 0 3.047 3.047m-3.914 21.235h9.562c.961 0 1.711-.68 1.711-1.641c0-.914-.75-1.64-1.71-1.64H30.53V25.68c0-1.266-.656-2.11-1.828-2.11h-4.43c-.937 0-1.687.727-1.687 1.64c0 .962.75 1.642 1.687 1.642h2.532v10.757h-2.93c-.938 0-1.688.727-1.688 1.641c0 .96.75 1.64 1.688 1.64" />
@@ -144,7 +126,8 @@
     </div>
     {#if note}
     <div class="note">
-        {note}
+        <!-- eslint-disable-next-line svelte/no-at-html-tags -->
+        {@html note} <!-- TODO: sanitize this? It's written and maintained by us -->
     </div>
     {/if}
 </div>
@@ -183,33 +166,17 @@
 .badge {
     display: inline-flex;
     align-items: center;
-    /* border-radius: 999px; */
-    /* border: 1px solid var(--border-level-3); */
-    /* background: color-mix(in srgb, var(--bg-level-3) 92%, transparent); */
     color: var(--font-color-muted);
-    /* font-size: 0.68rem; */
-    /* font-weight: 600; */
-    /* letter-spacing: 0.01em; */
-    /* line-height: 1; */
-    /* padding: 3px 7px; */
-    /* cursor: default; */
     cursor: help;
     user-select: none;
 }
 
+/* TODO: rethink these colors */
 .badge.platform {
-    /* color: #f8dca4; */
-    /* border-color: color-mix(in srgb, var(--color-platform) 65%, #000); */
-    /* background: color-mix(in srgb, var(--color-platform) 18%, transparent); */
-    /* color: var(--color-input-accent); */
     color: #6B8CFF;
 }
 
 .badge.version {
-    /* color: color-mix(in srgb, var(--color-input-accent) 90%, #fff); */
-    /* border-color: color-mix(in srgb, var(--color-input-accent) 45%, transparent); */
-    /* background: color-mix(in srgb, var(--color-input-accent) 12%, transparent); */
-    /* color: #f8dca4; */
     color: #F0A500;
 }
 
@@ -281,6 +248,7 @@
 .setting {
     display: flex;
     flex: 1;
+    justify-content: flex-end;
 }
 
 .row-right .setting {
@@ -290,5 +258,16 @@
 .note {
     color: var(--font-color-muted);
     font-size: 0.9rem;
+}
+
+.note :global(code) {
+    padding: 2px 4px;
+    border-radius: var(--radius-level-4);
+    background: rgba(from var(--bg-level-2) r g b / 0.6);
+    backdrop-filter: blur(20px);
+    border: 1px solid var(--border-level-1);
+    box-shadow:
+        0 0 1px -1px rgba(0,0,0,0.7),
+        0 0 1px white inset;
 }
 </style>

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -3,6 +3,7 @@
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
     import {alert} from "$lib/stores/modals.svelte";
+    import Badge from "../Badge.svelte";
 
     interface Props {
         name?: string;
@@ -50,14 +51,6 @@
         if (badge.type === "version") return `Added in Ghostty v${since}`;
         return "";
     };
-
-    const infoBadgesWithTooltips = $derived.by(() =>
-        infoBadges.map((badge) => ({
-            ...badge,
-            key: `${badge.type}-${badge.label}`,
-            tooltipAttachment: createTooltipAttachment(() => getBadgeTooltip(badge))
-        }))
-    );
 </script>
 
 <div class="setting-item">
@@ -65,30 +58,10 @@
         {#if name}
         <div class="row-left">
             <div class="setting-name">{name}</div>
-            {#if infoBadgesWithTooltips.length > 0 || (isNonDefault && onReset)}
+            {#if infoBadges.length > 0 || (isNonDefault && onReset)}
                 <div class="setting-extra">
-                    {#each infoBadgesWithTooltips as badge (badge.key)}
-                        <span
-                            class="badge"
-                            class:platform={badge.type === "platform"}
-                            class:version={badge.type === "version"}
-                            role="img"
-                            aria-label={badge.label}
-                            {@attach badge.tooltipAttachment}
-                        >
-                        {#if badge.type === "platform"}
-                            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
-                                <path d="M0 0h56v56H0z" fill="none" />
-                                <path fill="currentColor" d="M6.086 43.293h14.672l-.633 4.313h-3.21c-1.079 0-1.993.89-1.993 1.992s.914 2.015 1.992 2.015h22.172c1.078 0 1.992-.914 1.992-2.015a2.006 2.006 0 0 0-1.992-1.992h-3.21l-.634-4.313h14.672c4.008 0 6.023-1.922 6.023-6.023V10.41c0-4.101-2.015-6.023-6.023-6.023H6.086C2.078 4.387.6 6.309.6 10.41v26.86c0 4.101 1.478 6.023 5.486 6.023M4.844 32.981c-.703 0-1.008-.282-1.008-1.008V10.48c0-1.665.727-2.32 2.32-2.32h43.688c1.617 0 2.32.655 2.32 2.32v21.492c0 .726-.305 1.008-1.008 1.008ZM28 40.973c-1.172 0-2.18-.985-2.18-2.18c0-1.148 1.008-2.156 2.18-2.156s2.18 1.008 2.18 2.156c0 1.195-1.008 2.18-2.18 2.18" />
-                            </svg>
-                        {/if}
-                        {#if badge.type === "version"}
-                            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
-                                <path d="M0 0h56v56H0z" fill="none" />
-                                <path fill="currentColor" d="M26.113 51.215c3.352 3.351 6.797 3.398 10.243-.024L51.19 36.38c3.422-3.422 3.375-6.89.024-10.242L28.293 3.262c-1.758-1.758-2.742-1.875-5.227-1.875H14.16c-2.484 0-3.258.61-5.015 2.367l-5.391 5.39c-1.781 1.782-2.367 2.555-2.367 5.04v8.906c0 2.46.093 3.469 1.875 5.226Zm2.532-2.836L5.91 25.645c-.469-.47-.75-.961-.75-1.735v-9.89c0-.727.258-1.22.75-1.711l6.375-6.375c.516-.493.985-.774 1.735-.774h9.867c.797 0 1.265.305 1.758.774l22.734 22.71c1.664 1.665 1.71 3.47-.023 5.18L33.823 48.356c-1.71 1.734-3.515 1.71-5.18.023M16.902 20.137c1.828 0 3.211-1.43 3.211-3.211c0-1.805-1.383-3.211-3.21-3.211c-1.829 0-3.212 1.406-3.212 3.21c0 1.782 1.383 3.212 3.211 3.212" />
-                            </svg>
-                        {/if}
-                    </span>
+                    {#each infoBadges as badge (badge.label)}
+                        <Badge type={badge.type} label={badge.label} tooltip={getBadgeTooltip(badge)} />
                     {/each}
 
                     {#if isNonDefault && onReset}
@@ -161,23 +134,6 @@
     display: inline-flex;
     align-items: center;
     gap: 5px;
-}
-
-.badge {
-    display: inline-flex;
-    align-items: center;
-    color: var(--font-color-muted);
-    cursor: help;
-    user-select: none;
-}
-
-/* TODO: rethink these colors */
-.badge.platform {
-    color: #6B8CFF;
-}
-
-.badge.version {
-    color: #F0A500;
 }
 
 .setting-info {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import type {Snippet} from "svelte";
+    import {onMount, type Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
 
@@ -8,12 +8,13 @@
         note?: string;
         platform?: GhosttyPlatform[];
         since?: string;
+        schemaDescription?: string;
         children: Snippet;
         onReset?: () => void;
         isNonDefault?: boolean;
     }
 
-    const {name = "", note = "", platform, since, children, onReset, isNonDefault = false}: Props = $props();
+    const {name = "", note = "", platform, since, schemaDescription, children, onReset, isNonDefault = false}: Props = $props();
     const tooltipAttachment = createTooltipAttachment("Reset to default");
 
 
@@ -29,22 +30,93 @@
         platform?.map((value) => platformLabelMap[value]).filter(Boolean) ?? []
     );
 
+        type RuntimePlatform = "macos" | "linux" | "other";
+
+    let runtimePlatform = $state<RuntimePlatform>("other");
+
+    onMount(() => {
+        const userAgent = navigator.userAgent.toLowerCase();
+        if (userAgent.includes("mac")) runtimePlatform = "macos";
+        else if (userAgent.includes("linux")) runtimePlatform = "linux";
+        else runtimePlatform = "other";
+    });
+
+    const supportedPlatformsByRuntime: Record<RuntimePlatform, GhosttyPlatform[]> = {
+        macos: ["macos"],
+        linux: ["linux", "gtk", "gtk-wayland", "gtk-x11"],
+        other: []
+    };
+
+    const isUnsupportedOnCurrentOS = $derived.by(() => {
+        if (!platform || platform.length === 0) return false;
+        if (runtimePlatform === "other") return true;
+        const supported = supportedPlatformsByRuntime[runtimePlatform];
+        return !platform.some((value) => supported.includes(value));
+    });
+
+    const getPlatformBadgeLabel = (labels: string[]) => {
+        if (labels.length === 0) return "";
+        if (labels.length === 1) return labels[0];
+        return `${labels[0]} +${labels.length - 1}`;
+    };
+
+    const parseVersion = (version: string) =>
+        version
+            .split(".")
+            .map((part) => Number.parseInt(part, 10))
+            .map((num) => Number.isFinite(num) ? num : 0);
+
+    const isSinceVisible = $derived.by(() => {
+        // if (!since) return false;
+        // if (!versionBaseline) return true;
+
+        // const settingParts = parseVersion(since);
+        // const baselineParts = parseVersion(versionBaseline);
+        // const maxLen = Math.max(settingParts.length, baselineParts.length);
+
+        // for (let i = 0; i < maxLen; i++) {
+        //     const settingNum = settingParts[i] ?? 0;
+        //     const baselineNum = baselineParts[i] ?? 0;
+        //     if (settingNum > baselineNum) return true;
+        //     if (settingNum < baselineNum) return false;
+        // }
+
+        // return false;
+        return !!since;
+    });
+
     const metadataBadges = $derived.by(() => {
-        const badges: string[] = [];
-        if (platformLabels.length === 1) badges.push(platformLabels[0]);
-        else if (platformLabels.length > 1) badges.push(`${platformLabels.length} platforms`);
-        if (since) badges.push(`New in ${since}`);
+        const badges: Array<{label: string, type: "unsupported" | "platform" | "version"}> = [];
+        if (isUnsupportedOnCurrentOS) badges.push({label: "Not available on this OS", type: "unsupported"});
+        const platformBadge = getPlatformBadgeLabel(platformLabels);
+        if (platformBadge) badges.push({label: platformBadge, type: "platform"});
+        if (isSinceVisible) badges.push({label: `New in ${since}`, type: "version"});
         return badges;
     });
 
-    const metadataTooltip = $derived.by(() => {
-        const lines: string[] = [];
-        if (platformLabels.length > 0) lines.push(`Available on: ${platformLabels.join(", ")}`);
-        if (since) lines.push(`Introduced in Ghostty ${since}`);
-        return lines.join("\n");
-    });
+    const getBadgeTooltip = (badge: {label: string, type: "unsupported" | "platform" | "version"}) => {
+        switch (badge.type) {
+            case "unsupported":
+                return "Not available on your current operating system";
+            case "platform":
+                return platformLabels.length > 1 ? `Available on: ${platformLabels.join(", ")}` : `Platform: ${platformLabels[0]}`;
+            case "version":
+                return `Introduced in Ghostty ${since}`;
+            default:
+                return "";
+        }
+    };
 
-    const metadataTooltipAttachment = createTooltipAttachment(() => metadataTooltip);
+    const metadataBadgesWithTooltips = $derived.by(() =>
+        metadataBadges.map((badge) => ({
+            ...badge,
+            key: `${badge.type}-${badge.label}`,
+            tooltipAttachment: createTooltipAttachment(() => getBadgeTooltip(badge))
+        }))
+    );
+
+    const schemaDescriptionTooltip = $derived(schemaDescription || "");
+    const schemaDescriptionAttachment = createTooltipAttachment(() => schemaDescriptionTooltip);
 </script>
 
 <div class="setting-item">
@@ -52,12 +124,21 @@
         {#if name}
         <div class="setting-name-wrapper">
             <div class="setting-name">{name}</div>
-            {#if metadataBadges.length > 0}
+            {#if metadataBadgesWithTooltips.length > 0 || schemaDescription}
                 <div class="metadata" aria-label="Setting metadata">
-                    {#each metadataBadges as badge (badge)}
-                        <span class="metadata-badge">{badge}</span>
+                    {#each metadataBadgesWithTooltips as badge (badge.key)}
+                        <span
+                            class="metadata-badge"
+                            class:warning={badge.type === "unsupported"}
+                            class:version={badge.type === "version"}
+                            role="img"
+                            aria-label={badge.label}
+                            {@attach badge.tooltipAttachment}
+                        >{badge.label}</span>
                     {/each}
-                    <button type="button" class="metadata-info" aria-label="More metadata information" {@attach metadataTooltipAttachment}>i</button>
+                    {#if schemaDescription}
+                        <button type="button" class="metadata-info" aria-label="Full description" {@attach schemaDescriptionAttachment}>i</button>
+                    {/if}
                 </div>
             {/if}
             {#if isNonDefault && onReset}
@@ -129,6 +210,19 @@
     letter-spacing: 0.01em;
     line-height: 1;
     padding: 3px 7px;
+    cursor: default;
+}
+
+.metadata-badge.warning {
+    color: #f8dca4;
+    border-color: color-mix(in srgb, var(--color-warning) 65%, #000);
+    background: color-mix(in srgb, var(--color-warning) 18%, transparent);
+}
+
+.metadata-badge.version {
+    color: color-mix(in srgb, var(--color-input-accent) 90%, #fff);
+    border-color: color-mix(in srgb, var(--color-input-accent) 45%, transparent);
+    background: color-mix(in srgb, var(--color-input-accent) 12%, transparent);
 }
 
 .metadata-info {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,17 +1,50 @@
 <script lang="ts">
     import type {Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
+    import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
 
     interface Props {
         name?: string;
         note?: string;
+        platform?: GhosttyPlatform[];
+        since?: string;
         children: Snippet;
         onReset?: () => void;
         isNonDefault?: boolean;
     }
 
-    const {name = "", note = "", children, onReset, isNonDefault = false}: Props = $props();
+    const {name = "", note = "", platform, since, children, onReset, isNonDefault = false}: Props = $props();
     const tooltipAttachment = createTooltipAttachment("Reset to default");
+
+
+     const platformLabelMap: Record<GhosttyPlatform, string> = {
+        "macos": "macOS",
+        "linux": "Linux",
+        "gtk": "GTK",
+        "gtk-wayland": "GTK Wayland",
+        "gtk-x11": "GTK X11"
+    };
+
+    const platformLabels = $derived(
+        platform?.map((value) => platformLabelMap[value]).filter(Boolean) ?? []
+    );
+
+    const metadataBadges = $derived.by(() => {
+        const badges: string[] = [];
+        if (platformLabels.length === 1) badges.push(platformLabels[0]);
+        else if (platformLabels.length > 1) badges.push(`${platformLabels.length} platforms`);
+        if (since) badges.push(`New in ${since}`);
+        return badges;
+    });
+
+    const metadataTooltip = $derived.by(() => {
+        const lines: string[] = [];
+        if (platformLabels.length > 0) lines.push(`Available on: ${platformLabels.join(", ")}`);
+        if (since) lines.push(`Introduced in Ghostty ${since}`);
+        return lines.join("\n");
+    });
+
+    const metadataTooltipAttachment = createTooltipAttachment(() => metadataTooltip);
 </script>
 
 <div class="setting-item">
@@ -19,6 +52,14 @@
         {#if name}
         <div class="setting-name-wrapper">
             <div class="setting-name">{name}</div>
+            {#if metadataBadges.length > 0}
+                <div class="metadata" aria-label="Setting metadata">
+                    {#each metadataBadges as badge (badge)}
+                        <span class="metadata-badge">{badge}</span>
+                    {/each}
+                    <button type="button" class="metadata-info" aria-label="More metadata information" {@attach metadataTooltipAttachment}>i</button>
+                </div>
+            {/if}
             {#if isNonDefault && onReset}
             <div class="reset-button-wrapper">
                 <button
@@ -68,6 +109,49 @@
 
 .setting-name {
     font-weight: 500;
+}
+
+.metadata {
+    display: inline-flex;
+    align-items: center;
+    gap: 5px;
+}
+
+.metadata-badge {
+    display: inline-flex;
+    align-items: center;
+    border-radius: 999px;
+    border: 1px solid var(--border-level-3);
+    background: color-mix(in srgb, var(--bg-level-3) 92%, transparent);
+    color: var(--font-color-muted);
+    font-size: 0.68rem;
+    font-weight: 600;
+    letter-spacing: 0.01em;
+    line-height: 1;
+    padding: 3px 7px;
+}
+
+.metadata-info {
+    display: inline-flex;
+    align-items: center;
+    justify-content: center;
+    width: 16px;
+    height: 16px;
+    border-radius: 50%;
+    border: 1px solid var(--border-level-3);
+    background: color-mix(in srgb, var(--bg-level-3) 90%, transparent);
+    color: var(--font-color-muted);
+    font-size: 0.65rem;
+    font-weight: 700;
+    cursor: help;
+    user-select: none;
+}
+
+.metadata-info:focus-visible,
+.metadata-info:hover {
+    border-color: var(--color-input-accent);
+    color: var(--font-color);
+    outline: none;
 }
 
 .reset-button-wrapper {

--- a/src/lib/components/settings/Text.svelte
+++ b/src/lib/components/settings/Text.svelte
@@ -16,7 +16,7 @@
     }
 </script>
 
-<input class:blank class:empty={value === ""} class={align} type="text" {placeholder} style:width="{size}ch" onclick={click} onchange={change} bind:value />
+<input class:blank class:empty={value === ""} class={align} type="text" {placeholder} style:width={size ? `${size}ch` : "auto"} onclick={click} onchange={change} bind:value />
 
 <style>
 input {

--- a/src/lib/components/settings/Text.svelte
+++ b/src/lib/components/settings/Text.svelte
@@ -4,18 +4,19 @@
         placeholder?: string;
         blank?: boolean;
         align?: "right" | "left";
+        size?: number;
         change?: (e: Event) => void;
     }
 
     // eslint-disable-next-line prefer-const
-    let {value = $bindable(), placeholder = "", blank = false, align = "right", change}: Props = $props();
+    let {value = $bindable(), placeholder = "", blank = false, align = "right", size, change}: Props = $props();
 
     function click(event: MouseEvent) {
         event.stopPropagation();
     }
 </script>
 
-<input class:blank class:empty={value === ""} class={align} type="text" {placeholder} onclick={click} onchange={change} bind:value />
+<input class:blank class:empty={value === ""} class={align} type="text" {placeholder} style:width="{size}ch" onclick={click} onchange={change} bind:value />
 
 <style>
 input {

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -7,6 +7,7 @@ interface BaseSettingType {
     note?: string;
     platform?: GhosttyPlatform[];
     since?: string;
+    schemaDescription?: string;
 }
 
 interface Panel extends BaseSettingType {
@@ -587,12 +588,12 @@ const kebabToCamel = (key: string) =>
 
 const schemaMetadataById = new Map(
     ghosttySchema
-        .filter(setting => setting.platform || setting.since)
         .map(setting => [
             kebabToCamel(setting.key),
             {
                 platform: setting.platform,
-                since: setting.since
+                since: setting.since,
+                description: setting.description,
             }
         ])
 );
@@ -609,7 +610,8 @@ const settings = baseSettings.map((panel) => ({
             return {
                 ...setting,
                 platform: metadata.platform,
-                since: metadata.since
+                since: metadata.since,
+                schemaDescription: metadata.description,
             };
         })
     }))

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -157,8 +157,8 @@ const baseSettings = [
                     {id: "configDefaultFiles", name: "Load default config file", type: "switch", value: true},
                     {id: "link", name: "Link handling", note: "Regex for making clickable links, currently disabled.", type: "text", value: "", disabled: true},
                     {id: "linkUrl", name: "Automatically link URLs", note: "Matching occurs while holding the control (Linux) or command (macOS) key.", type: "switch", value: true},
-                    {id: "linkPreviews", name: "Show link previews", note: "When set to `osc8`, previews are only shown for hyperlinks created with the OSC 8 sequence.", type: "dropdown", value: "true", options: ["true", "false", "osc8"]},
-                    {id: "undoTimeout", name: "Undo timeout", note: "Timeout for undo operations. Format like `1h30m`, `5s`, `500ms`.", type: "text", value: ""}
+                    {id: "linkPreviews", name: "Show link previews", note: "When set to <code>osc8</code>, previews are only shown for hyperlinks created with the OSC 8 sequence.", type: "dropdown", value: "true", options: ["true", "false", "osc8"]},
+                    {id: "undoTimeout", name: "Undo timeout", note: "Timeout for undo operations. Format like <code>1h30m</code>, <code>5s</code>, <code>500ms</code>.", type: "text", value: ""}
                 ]
             },
             {
@@ -173,7 +173,7 @@ const baseSettings = [
                     {id: "maximize", name: "Launch as maximized window", type: "switch", value: false},
                     {id: "fullscreen", name: "Launch in fullscreen mode", type: "switch", value: false},
                     {id: "initialWindow", name: "Show a window on startup", type: "switch", value: true},
-                    {id: "workingDirectory", name: "Directory to use after startup", note: "Special values of `home` and `inherit` are also allowed here.", type: "text", value: ""},
+                    {id: "workingDirectory", name: "Directory to use after startup", note: "Special values of <code>home</code> and <code>inherit</code> are also allowed here.", type: "text", value: ""},
                 ]
             },
             {
@@ -194,7 +194,7 @@ const baseSettings = [
                 // type: "group",
                 settings: [
                     {id: "shellIntegration", name: "Shell integration style", type: "dropdown", value: "detect", options: ["none", "detect", "bash", "elvish", "fish", "nushell", "zsh"]},
-                    {id: "shellIntegrationFeatures", name: "Shell integration features", note: "Available features: cursor, sudo, title, ssh-env, ssh-terminfo, path. Including one force enables it, prefixing it with `no-` force disables it, omitting it falls back to default.", type: "text", value: "cursor,no-sudo,title,no-ssh-env,no-ssh-terminfo,path"},
+                    {id: "shellIntegrationFeatures", name: "Shell integration features", note: "Available features: cursor, sudo, title, ssh-env, ssh-terminfo, path. Including one force enables it, prefixing it with <code>no-</code> force disables it, omitting it falls back to default.", type: "text", value: "cursor,no-sudo,title,no-ssh-env,no-ssh-terminfo,path"},
                     {id: "term", name: "TERM environment variable", type: "text", value: "xterm-ghostty"},
                     {id: "titleReport", name: "CSI 21 title reporting", note: "This allows running apps to read the terminal title.", type: "switch", value: false},
                 ]
@@ -205,7 +205,7 @@ const baseSettings = [
                 settings: [
                     {id: "quickTerminalPosition", name: "Terminal position", type: "dropdown", value: "top", options: ["top", "right", "bottom", "left", "center"]},
                     {id: "quickTerminalScreen", name: "Screen location", type: "dropdown", value: "main", options: ["main", "mouse", "macos-menu-bar"]},
-                    {id: "quickTerminalSize", name: "Quick terminal size", note: "Specify the size as a percentage (e.g. `50%`) or in pixels (e.g. `800`). You can specify two values separated by a comma for width and height.", type: "text", value: ""},
+                    {id: "quickTerminalSize", name: "Quick terminal size", note: "Specify the size as a percentage (e.g. <code>50%</code>) or in pixels (e.g. <code>800</code>). You can specify two values separated by a comma for width and height.", type: "text", value: ""},
                     {id: "quickTerminalAnimationDuration", name: "Animation duration", type: "number", value: 0.2, min: 0, max: 10, step: 0.1, range: true},
                     {id: "quickTerminalAutohide", name: "Autohide", note: "This autohides the quick terminal when focus shifts away.", type: "switch", value: true},
                     {id: "quickTerminalSpaceBehavior", name: "macOS space behavior", type: "dropdown", value: "move", options: ["move", "remain"]},
@@ -232,8 +232,8 @@ const baseSettings = [
                 id: "bell",
                 name: "Bell",
                 settings: [
-                    {id: "bellFeatures", name: "Bell features", note: "Comma-separated list of features. Available: system, audio, attention, title, border. Prefix with `no-` to disable.", type: "text", value: ""},
-                    {id: "bellAudioPath", name: "Bell audio file", note: "Path to an audio file to play when the bell rings. Requires `audio` in bell features. GTK only.", type: "text", value: ""},
+                    {id: "bellFeatures", name: "Bell features", note: "Comma-separated list of features. Available: system, audio, attention, title, border. Prefix with <code>no-</code> to disable.", type: "text", value: ""},
+                    {id: "bellAudioPath", name: "Bell audio file", note: "Path to an audio file to play when the bell rings. Requires <code>audio</code> in bell features. GTK only.", type: "text", value: ""},
                     {id: "bellAudioVolume", name: "Bell audio volume", note: "Volume for the bell audio, from 0 (silent) to 1 (full). GTK only.", type: "number", range: true, value: 0.5, min: 0, max: 1, step: 0.05},
                 ]
             },
@@ -295,7 +295,7 @@ const baseSettings = [
                     {id: "windowTitlebarForeground", name: "Titlebar foreground", type: "color", value: ""},
                     {id: "backgroundOpacity", name: "Background opacity", type: "number", range: true, value: 1, min: 0, max: 1, step: 0.01},
                     {id: "backgroundOpacityCells", name: "Force background opacity on cells.", type: "switch", value: false},
-                    {id: "backgroundBlur", name: "Background blur", note: "Set to `true` to enable blur, `false` to disable, a number for a specific radius (macOS), or `macos-glass-regular`/`macos-glass-clear` for macOS glass effects.", type: "text", value: "false"},
+                    {id: "backgroundBlur", name: "Background blur", note: "Set to <code>true</code> to enable blur, <code>false</code> to disable, a number for a specific radius (macOS), or <code>macos-glass-regular</code>/<code>macos-glass-clear</code> for macOS glass effects.", type: "text", value: "false"},
                     {id: "backgroundImage", name: "Background image", note: "Path to an image file to use as the terminal background.", type: "text", value: ""},
                     {id: "backgroundImageOpacity", name: "Background image opacity", type: "number", range: true, value: 1, min: 0, max: 1, step: 0.01},
                     {id: "backgroundImagePosition", name: "Background image position", type: "dropdown", value: "center", options: ["center", "top-left", "top-center", "top-right", "center-left", "center-center", "center-right", "bottom-left", "bottom-center", "bottom-right"]},
@@ -340,7 +340,7 @@ const baseSettings = [
                         value: "",
                         options: [{name: "Custom", value: ""}]
                     },
-                    {id: "boldColor", name: "Bold text color", note: "Set to `bright` to use bright palette colors for bold text, or a hex color value. Leave empty to use the default.", type: "text", value: ""},
+                    {id: "boldColor", name: "Bold text color", note: "Set to <code>bright</code> to use bright palette colors for bold text, or a hex color value. Leave empty to use the default.", type: "text", value: ""},
                     {id: "faintOpacity", name: "Faint text opacity", type: "number", range: true, value: 0.5, min: 0, max: 1, step: 0.01},
                     {id: "minimumContrast", name: "Minimum contrast", type: "number", value: 1, range: true, min: 1, max: 21, step: 0.1},
                     {id: "paletteGenerate", name: "Auto-generate missing palette colors", note: "When enabled, Ghostty will generate missing colors (indices 16-231) based on the first 16.", type: "switch", value: true},
@@ -370,7 +370,7 @@ const baseSettings = [
                     {id: "cursorText", name: "Text color under cursor", type: "color", value: ""},
                     {id: "cursorOpacity", name: "Cursor opacity", type: "number", value: 1, range: true, min: 0, max: 1, step: 0.05},
                     {id: "cursorStyle", name: "Cursor style", type: "dropdown", value: "block", options: ["block", "bar", "underline", {value: "block_hollow", name: "hollow block"}]},
-                    {id: "cursorStyleBlink", name: "Cursor blink style", note: "The `default` option defers to DEC mode 12 to determine blinking state.", type: "dropdown", value: "", options: ["true", "false", {value: "", name: "default"}]},
+                    {id: "cursorStyleBlink", name: "Cursor blink style", note: "The <code>default</code> option defers to DEC mode 12 to determine blinking state.", type: "dropdown", value: "", options: ["true", "false", {value: "", name: "default"}]},
                 ]
             },
             {
@@ -415,7 +415,7 @@ const baseSettings = [
             {
                 id: "styles",
                 name: "Font Styles",
-                note: "Named font styles for the fields above. For example for `Ioveska Heavy` you would use a style of `Heavy`. Alternately you can set the style to `false` to completely disable the style and revert to default style.",
+                note: "Named font styles for the fields above. For example for <code>Ioveska Heavy</code> you would use a style of <code>Heavy</code>. Alternately you can set the style to <code>false</code> to completely disable the style and revert to default style.",
                 settings: [
                     {id: "fontStyle", name: "Main font style", type: "text", value: "default"},
                     {id: "fontStyleBold", name: "Font style for bold text", type: "text", value: "default"},
@@ -501,12 +501,12 @@ const baseSettings = [
                 id: "main",
                 name: "",
                 settings: [
-                    {id: "class", name: "WM_CLASS class field", note: "This defaults to `com.mitchellh.ghostty`", type: "text", value: ""},
-                    {id: "x11InstanceName", name: "WM_CLASS instance name", note: "This defaults to `ghostty`", type: "text", value: ""},
+                    {id: "class", name: "WM_CLASS class field", note: "This defaults to <code>com.mitchellh.ghostty</code>", type: "text", value: ""},
+                    {id: "x11InstanceName", name: "WM_CLASS instance name", note: "This defaults to <code>ghostty</code>", type: "text", value: ""},
                     {id: "gtkSingleInstance", name: "Single-instance mode", type: "dropdown", value: "detect", options: ["detect", "true", "false"]},
                     {id: "gtkCustomCss", name: "Custom css file", type: "text", value: ""},
                     {id: "gtkOpenglDebug", name: "OpenGL debug", type: "switch", value: false},
-                    {id: "appNotifications", name: "App notifications", note: "Comma-separated list of notifications to enable/disable. Available: clipboard-copy, config-reload. Prefix with `no-` to disable. `true`/`false` to enable/disable all.", type: "text", value: ""},
+                    {id: "appNotifications", name: "App notifications", note: "Comma-separated list of notifications to enable/disable. Available: clipboard-copy, config-reload. Prefix with <code>no-</code> to disable. <code>true</code>/<code>false</code> to enable/disable all.", type: "text", value: ""},
                 ]
             },
             {
@@ -514,9 +514,9 @@ const baseSettings = [
                 name: "Titlebar & Tabs",
                 settings: [
                     {id: "gtkToolbarStyle", name: "Toolbar style", type: "dropdown", value: "raised", options: ["raised", "flat", "raised-border"]},
-                    {id: "gtkTitlebarStyle", name: "Titlebar style", note: "`tabs` merges the tab bar and titlebar to save vertical space.", type: "dropdown", value: "native", options: ["native", "tabs"]},
+                    {id: "gtkTitlebarStyle", name: "Titlebar style", note: "<code>tabs</code> merges the tab bar and titlebar to save vertical space.", type: "dropdown", value: "native", options: ["native", "tabs"]},
                     {id: "gtkTabsLocation", name: "Tab location", type: "dropdown", value: "top", options: ["top", "bottom"]},
-                    {id: "gtkWideTabs", name: "Use wide tabs", note: "Setting this to false will make tabs use the least space necessary.", type: "switch", value: true},
+                    {id: "gtkWideTabs", name: "Use wide tabs", note: "Setting this to <code>false</code> will make tabs use the least space necessary.", type: "switch", value: true},
                     {id: "gtkTitlebar", name: "Show titlebar", type: "switch", value: true},
                     {id: "gtkTitlebarHideWhenMaximized", name: "Hide titlebar on maximize", type: "switch", value: false},
                     {id: "gtkQuickTerminalLayer", name: "Quick terminal layer", note: "Controls which layer the quick terminal appears on. GTK Wayland only.", type: "dropdown", value: "top", options: ["overlay", "top", "bottom", "background"]},
@@ -570,10 +570,10 @@ const baseSettings = [
             {
                 id: "icon",
                 name: "App Icon",
-                note: "If you choose the \"custom-style\" option, you can use any of the other icon settings to customize your icon with a live preview.",
+                note: "If you choose the <code>custom-style</code> option, you can use any of the other icon settings to customize your icon with a live preview.",
                 settings: [
                     {id: "macosIcon", name: "Icon", note: "Custom style must specify both ghost and screen colors.", type: "dropdown", value: "official", options: ["official", "blueprint", "chalkboard", "microchip", "glass", "holographic", "paper", "retro", "xray", "custom", "custom-style"]},
-                    {id: "macosCustomIcon", name: "Icon file", note: "Only used when \"custom\" is selected above.", type: "text", value: ""},
+                    {id: "macosCustomIcon", name: "Icon file", note: "Only used when <code>custom</code> is selected above.", type: "text", value: ""},
                     {id: "macosIconFrame", name: "Icon frame", type: "dropdown", value: "aluminum", options: ["aluminum", "beige", "plastic", "chrome"]},
                     {id: "macosIconGhostColor", name: "Ghost color", type: "color", value: ""},
                     {id: "macosIconScreenColor", name: "Screen color", type: "color", value: ""},

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -1,9 +1,12 @@
 import type {HexColor} from "$lib/utils/colors";
+import ghosttySchema, {type GhosttyPlatform} from "$lib/data/ghostty-schema";
 
 interface BaseSettingType {
     id: string;
     name: string;
     note?: string;
+    platform?: GhosttyPlatform[];
+    since?: string;
 }
 
 interface Panel extends BaseSettingType {
@@ -135,7 +138,7 @@ const getOS = () => {
 
 // TODO: find a good way to properly type the settings
 // TODO: also allow clearable settings and such, this is a mess
-const settings = [
+const baseSettings = [
     {
         id: "application",
         name: "Application",
@@ -577,6 +580,40 @@ const settings = [
         ]
     },
 ] as Panel[];
+
+
+const kebabToCamel = (key: string) =>
+    key.replace(/-([a-z])/g, (_, char: string) => char.toUpperCase());
+
+const schemaMetadataById = new Map(
+    ghosttySchema
+        .filter(setting => setting.platform || setting.since)
+        .map(setting => [
+            kebabToCamel(setting.key),
+            {
+                platform: setting.platform,
+                since: setting.since
+            }
+        ])
+);
+
+// TODO: this is gross, ideally the settings data would be generated from the
+// schema directly instead of having to be merged like this, but this will do for now
+const settings = baseSettings.map((panel) => ({
+    ...panel,
+    groups: panel.groups.map((group) => ({
+        ...group,
+        settings: group.settings.map((setting) => {
+            const metadata = schemaMetadataById.get(setting.id);
+            if (!metadata) return setting;
+            return {
+                ...setting,
+                platform: metadata.platform,
+                since: metadata.since
+            };
+        })
+    }))
+})) as Panel[];
 
 
 export default settings;

--- a/src/lib/data/settings.ts
+++ b/src/lib/data/settings.ts
@@ -35,6 +35,7 @@ interface Text extends BaseSettingItem {
     type: "text";
     value: string;
     placeholder?: string;
+    size?: number;
 }
 
 interface Number extends BaseSettingItem {
@@ -519,7 +520,7 @@ const baseSettings = [
                     {id: "gtkTitlebar", name: "Show titlebar", type: "switch", value: true},
                     {id: "gtkTitlebarHideWhenMaximized", name: "Hide titlebar on maximize", type: "switch", value: false},
                     {id: "gtkQuickTerminalLayer", name: "Quick terminal layer", note: "Controls which layer the quick terminal appears on. GTK Wayland only.", type: "dropdown", value: "top", options: ["overlay", "top", "bottom", "background"]},
-                    {id: "gtkQuickTerminalNamespace", name: "Quick terminal namespace", note: "Identifier for the quick terminal layer surface. GTK Wayland only.", type: "text", value: "ghostty-quick-terminal"},
+                    {id: "gtkQuickTerminalNamespace", name: "Quick terminal namespace", note: "Identifier for the quick terminal layer surface. GTK Wayland only.", type: "text", value: "ghostty-quick-terminal", size: 18},
                 ]
             }
         ]

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -57,7 +57,8 @@
                     <Item
                         name={setting.name}
                         note={setting.note}
-                        platform={setting.platform}
+                        // filter out the current platform from the badge list since it's already obvious from the UI
+                        platform={setting.platform?.filter(p => p !== title?.toLowerCase())}
                         since={setting.since}
                         schemaDescription={setting.type !== "palette" ? setting.schemaDescription : undefined}
                         isNonDefault={isNonDefault(setting.id as keyof typeof config)}

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -59,7 +59,7 @@
                         note={setting.note}
                         platform={setting.platform}
                         since={setting.since}
-                        schemaDescription={setting.schemaDescription}
+                        schemaDescription={setting.type !== "palette" ? setting.schemaDescription : undefined}
                         isNonDefault={isNonDefault(setting.id as keyof typeof config)}
                         onReset={() => {
                             resetSetting(setting.id as keyof typeof config);

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -57,6 +57,8 @@
                     <Item
                         name={setting.name}
                         note={setting.note}
+                        platform={setting.platform}
+                        since={setting.since}
                         isNonDefault={isNonDefault(setting.id as keyof typeof config)}
                         onReset={() => {
                             resetSetting(setting.id as keyof typeof config);

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -59,6 +59,7 @@
                         note={setting.note}
                         platform={setting.platform}
                         since={setting.since}
+                        schemaDescription={setting.schemaDescription}
                         isNonDefault={isNonDefault(setting.id as keyof typeof config)}
                         onReset={() => {
                             resetSetting(setting.id as keyof typeof config);

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -69,7 +69,7 @@
                         {#if setting.type === "switch"}
                             <Switch bind:checked={config[setting.id as keyof typeof config] as boolean} />
                         {:else if setting.type === "text"}
-                            <Text bind:value={config[setting.id as keyof typeof config] as string} placeholder={setting.placeholder} />
+                            <Text bind:value={config[setting.id as keyof typeof config] as string} placeholder={setting.placeholder} size={setting.size} />
                         {:else if setting.type === "number"}
                             <Number bind:value={config[setting.id as keyof typeof config] as number} range={setting.range} min={setting.min} max={setting.max} step={setting.step} size={setting.size} placeholder={setting.placeholder} />
                         {:else if setting.type === "dropdown"}


### PR DESCRIPTION
Basically this adds a platform and version badge to settings where its relevant. It also adds an info icon to the right of each setting that you can click on that pulls up the full original help text from ghostty in a modal.

Only AI used was for the summary below

## Copilot Generated Summary

This pull request enhances the settings UI and modal system by improving the rendering and styling of notes and descriptions, adding support for displaying platform and version badges, and making the settings schema more expressive. It also introduces the `marked` library for Markdown parsing in modals and refines several UI components for better clarity and accessibility.

**Settings UI Improvements:**

* Added support for displaying platform and version badges in `Item.svelte`, including tooltips and icons, based on new `platform` and `since` fields in the settings schema. Also added an info button to show full descriptions when available. [[1]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L2-R130) [[2]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L63-R211)
* Updated the settings schema (`settings.ts`) to include `platform`, `since`, and `schemaDescription` fields for each setting, and improved the typing for text settings by adding a `size` property. [[1]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117R2-R10) [[2]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117R38)
* Updated various setting notes to use inline code formatting (`<code>`) for improved readability. [[1]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117L155-R161) [[2]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117L171-R176) [[3]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117L192-R197) [[4]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117L203-R208)

**Modal and Markdown Rendering:**

* Switched modal message rendering to use the `marked` library for Markdown support, enabling richer formatting in alert modals. [[1]](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519L43-R44) [[2]](diffhunk://#diff-8efeaddca6a0330dd2c48b399b1ae3cfdd16caa531199499b7bd7c98823f22c4R2) [[3]](diffhunk://#diff-8efeaddca6a0330dd2c48b399b1ae3cfdd16caa531199499b7bd7c98823f22c4L30-R32)
* Allowed HTML rendering for setting group notes and item notes, with a reminder to sanitize as needed. [[1]](diffhunk://#diff-4deeabfcff9d5eff2eb61b7bfd7919aedc4d3a2f993f800c5314e54d2cb86493L18-R19) [[2]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L2-R130)

**Styling and Accessibility:**

* Added and improved CSS styles for badges, code blocks, and modal/setting notes, ensuring consistent and visually distinct rendering of code and badges across the UI. [[1]](diffhunk://#diff-8efeaddca6a0330dd2c48b399b1ae3cfdd16caa531199499b7bd7c98823f22c4L46-R70) [[2]](diffhunk://#diff-4deeabfcff9d5eff2eb61b7bfd7919aedc4d3a2f993f800c5314e54d2cb86493R57-R67) [[3]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L63-R211) [[4]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L109-R245) [[5]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405R254-R272)
* Refactored the structure of the settings item layout for better alignment and accessibility, including new classes for left/right alignment and improved button focus/hover states. [[1]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L63-R211) [[2]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L109-R245) [[3]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405R254-R272)

**Other Enhancements:**

* Added an optional `size` prop to the `Text.svelte` component to control input width in characters. [[1]](diffhunk://#diff-3c175ce87e42894d9347013264f2cb2f8f9d1d65a0674b5f259d9a0fc5c1922eR7-R19) [[2]](diffhunk://#diff-4bb24ab36a4f780ba019b595edc5a9f0d1bdac353ab0f952f4278011093d8117R38)

These changes collectively make the settings UI more informative, visually appealing, and easier to maintain.