### PR TITLE
Add search to the sidebar (with results)

### DIFF
--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -18,6 +18,8 @@
     import macos from "$lib/images/tabs/macos.webp";
 
     import type {Snippet} from "svelte";
+    import {scale} from "svelte/transition";
+
 
     interface SearchResult {
         categoryId: string;
@@ -37,6 +39,7 @@
 
     const {children}: {children: Snippet} = $props();
 
+    // TODO: this is pretty expensive to compute on every keystroke, consider precomputing and caching searchableText in the settings data
     const searchableSettings = $derived.by(() => {
         const results: SearchResult[] = [];
         for (const category of settings) {
@@ -68,6 +71,7 @@
 
     let searchQuery = $state("");
     let selectedSearchIndex = $state(-1);
+    let activeSearchIndex = $state(-1);
 
     const normalizedSearchQuery = $derived(searchQuery.trim().toLocaleLowerCase());
     const searchTokens = $derived(normalizedSearchQuery.split(/\s+/).filter(Boolean));
@@ -77,6 +81,8 @@
         return searchableSettings.filter(result => searchTokens.every(token => result.searchableText.includes(token)));
     });
 
+    // TODO: this grouping is also a bit expensive, consider memoizing based on the filtered results
+    // also move grouping logic to a utility function
     const groupedSearchResults = $derived.by(() => {
         const grouped: Array<{
             categoryId: string;
@@ -103,6 +109,8 @@
         return grouped;
     });
 
+    // TODO: this is a bit janky, consider a more robust solution for keeping track of active/selected search results and their corresponding DOM elements
+    // also move to search utility
     function getHighlightParts(value: string, query: string): HighlightPart[] {
         if (!value) return [];
 
@@ -220,7 +228,16 @@
         const input = event.currentTarget as HTMLInputElement;
         searchQuery = input.value;
         selectedSearchIndex = input.value.trim() ? 0 : -1;
+        activeSearchIndex = -1;
     }
+
+    // Scroll selected search result into view when it changes
+    $effect(() => {
+        if (selectedSearchIndex < 0) return;
+        const target = document.getElementById(`search-result-${selectedSearchIndex.toString()}`) as HTMLAnchorElement | null;
+        if (!target) return;
+        target.scrollIntoView({block: "nearest"});
+    });
 </script>
 
 <svelte:window onkeydown={handleWindowKeydown} />
@@ -249,9 +266,11 @@
             class="search-clear-button"
             type="button"
             title="Clear search"
+            transition:scale={{duration: 150}}
             onclick={() => {
                 searchQuery = "";
                 selectedSearchIndex = -1;
+                activeSearchIndex = -1;
             }}
         >
             <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
@@ -268,7 +287,13 @@
             {#if groupedSearchResults.length}
                 {#each groupedSearchResults as category (category.categoryId)}
                     <section class="search-category">
-                        <Tab route={category.categoryRoute}>
+                        <Tab
+                            route={category.categoryRoute}
+                            onClick={() => {
+                                activeSearchIndex = -1; // tab selection is inside component for now
+                            }}
+                        >
+                            <!-- TODO: a lot of de-duping with the main sidebar -->
                             {#snippet icon()}
                                 {#if category.categoryId === "application"}
                                     <img src={application} alt="Application Settings" />
@@ -300,13 +325,15 @@
                                 <a href={getSearchResultHref(result)}
                                     id={`search-result-${result.index.toString()}`}
                                     class="search-result"
+                                    class:active={result.index === activeSearchIndex}
                                     class:selected={result.index === selectedSearchIndex}
                                     role="option"
                                     aria-selected={result.index === selectedSearchIndex}
-                                    onmousemove={() => selectedSearchIndex = result.index}
+                                    // onmousemove={() => selectedSearchIndex = result.index}
                                     onclick={() => {
-                                        searchQuery = "";
+                                        // searchQuery = "";
                                         selectedSearchIndex = -1;
+                                        activeSearchIndex = result.index;
                                     }}
                                 >
                                     <span class="search-result-name">
@@ -348,7 +375,15 @@
                     </section>
                 {/each}
             {:else}
-                <p class="search-empty">No settings match "{searchQuery.trim()}".</p>
+                <div class="search-blankslate">
+                    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56" class="search-icon">
+                        <path d="M0 0h56v56H0z" fill="none" />
+                        <path fill="currentColor" d="M23.957 41.77a18.02 18.02 0 0 0 10.477-3.376l11.109 11.11a2.66 2.66 0 0 0 1.898.773c1.524 0 2.625-1.172 2.625-2.672c0-.703-.234-1.359-.75-1.874L38.277 34.668c2.32-3.047 3.703-6.82 3.703-10.922c0-9.914-8.109-18.023-18.023-18.023c-9.937 0-18.023 8.109-18.023 18.023S14.02 41.77 23.957 41.77m0-3.891c-7.758 0-14.133-6.398-14.133-14.133S16.2 9.613 23.957 9.613c7.734 0 14.133 6.399 14.133 14.133c0 7.735-6.399 14.133-14.133 14.133" />
+                    </svg>
+                    <h2>No Results</h2>
+                    <p class="search-empty">No results for "{searchQuery.trim()}"</p>
+                </div>
+
             {/if}
         </div>
     {:else}
@@ -428,9 +463,33 @@
 #search-results {
     display: flex;
     flex-direction: column;
+    flex: 1;
     overflow-y: auto;
     min-height: 0;
     gap: 10px;
+}
+
+.search-blankslate {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    align-items: center;
+    justify-content: center;
+    gap: 6px;
+    color: var(--font-color-muted);
+    margin-top: calc(-50%); /* macOS has a similar offset centering */
+}
+
+.search-blankslate .search-icon {
+    width: 20px;
+    height: 20px;
+    margin-bottom: 8px;
+}
+
+.search-blankslate h2 {
+    margin: 0;
+    font-size: 1.2rem;
+    color: var(--font-color);
 }
 
 .search-empty {
@@ -468,6 +527,10 @@
 
 .search-result.selected,
 .search-result:hover {
+    background: rgba(255, 255, 255, 0.075);
+}
+
+.search-result.active {
     background: var(--color-selected);
 }
 

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -1,0 +1,453 @@
+<script lang="ts">
+    import {resolve} from "$app/paths";
+    import Tab from "$lib/components/Tab.svelte";
+    import settings from "$lib/data/settings";
+
+    import application from "$lib/images/tabs/application.webp";
+    import clipboard from "$lib/images/tabs/clipboard.webp";
+    import windowIcon from "$lib/images/tabs/window.webp";
+
+    import colors from "$lib/images/tabs/colors.webp";
+    import fonts from "$lib/images/tabs/fonts.webp";
+
+    import keybinds from "$lib/images/tabs/keybinds.webp";
+    import mouse from "$lib/images/tabs/mouse.webp";
+
+    import gtk from "$lib/images/tabs/gtk.svg";
+    import linux from "$lib/images/tabs/linux.webp";
+    import macos from "$lib/images/tabs/macos.webp";
+
+    import type {Snippet} from "svelte";
+
+    interface SearchResult {
+        categoryId: string;
+        categoryName: string;
+        groupName: string;
+        note: string;
+        routeKey: string;
+        settingId: string;
+        settingName: string;
+        searchableText: string;
+    }
+
+    interface HighlightPart {
+        matched: boolean;
+        text: string;
+    }
+
+    const {children}: {children: Snippet} = $props();
+
+    const searchableSettings = $derived.by(() => {
+        const results: SearchResult[] = [];
+        for (const category of settings) {
+            for (const group of category.groups) {
+                for (const setting of group.settings) {
+                    const searchableText = [
+                        category.name,
+                        group.name,
+                        setting.name,
+                        setting.note ?? ""
+                    ]
+                        .join(" ")
+                        .toLocaleLowerCase();
+                    results.push({
+                        categoryId: category.id,
+                        categoryName: category.name,
+                        groupName: group.name,
+                        note: setting.note ?? "",
+                        routeKey: `${category.id}:${setting.id}`,
+                        settingId: setting.id,
+                        settingName: setting.name,
+                        searchableText,
+                    });
+                }
+            }
+        }
+        return results;
+    });
+
+    let searchQuery = $state("");
+    let selectedSearchIndex = $state(-1);
+
+    const normalizedSearchQuery = $derived(searchQuery.trim().toLocaleLowerCase());
+    const searchTokens = $derived(normalizedSearchQuery.split(/\s+/).filter(Boolean));
+
+    const filteredSearchResults = $derived.by(() => {
+        if (!searchTokens.length) return [];
+        return searchableSettings.filter(result => searchTokens.every(token => result.searchableText.includes(token)));
+    });
+
+    const groupedSearchResults = $derived.by(() => {
+        const grouped: Array<{
+            categoryId: string;
+            categoryName: string;
+            categoryRoute: string;
+            results: Array<SearchResult & {index: number}>;
+        }> = [];
+
+        filteredSearchResults.forEach((result, index) => {
+            const existing = grouped.find(group => group.categoryId === result.categoryId);
+            if (existing) {
+                existing.results.push({...result, index});
+                return;
+            }
+
+            grouped.push({
+                categoryId: result.categoryId,
+                categoryName: result.categoryName,
+                categoryRoute: resolve("/settings/[category]", {category: result.categoryId}),
+                results: [{...result, index}],
+            });
+        });
+
+        return grouped;
+    });
+
+    function getHighlightParts(value: string, query: string): HighlightPart[] {
+        if (!value) return [];
+
+        const tokens = query
+            .trim()
+            .toLocaleLowerCase()
+            .split(/\s+/)
+            .filter(Boolean);
+
+        if (!tokens.length) {
+            return [{matched: false, text: value}];
+        }
+
+        const lowerValue = value.toLocaleLowerCase();
+        const ranges: Array<[number, number]> = [];
+        for (const token of tokens) {
+            let fromIndex = 0;
+            while (fromIndex < lowerValue.length) {
+                const index = lowerValue.indexOf(token, fromIndex);
+                if (index < 0) break;
+
+                ranges.push([index, index + token.length]);
+                fromIndex = index + token.length;
+            }
+        }
+
+        if (!ranges.length) {
+            return [{matched: false, text: value}];
+        }
+
+        ranges.sort((a, b) => a[0] - b[0]);
+
+        const merged: Array<[number, number]> = [ranges[0]];
+        for (let i = 1; i < ranges.length; i++) {
+            const range = ranges[i];
+            const last = merged[merged.length - 1];
+            if (range[0] <= last[1]) {
+                last[1] = Math.max(last[1], range[1]);
+            }
+            else {
+                merged.push(range);
+            }
+        }
+
+        const parts: HighlightPart[] = [];
+        let cursor = 0;
+        for (const [start, end] of merged) {
+            if (start > cursor) {
+                parts.push({matched: false, text: value.slice(cursor, start)});
+            }
+            parts.push({matched: true, text: value.slice(start, end)});
+            cursor = end;
+        }
+
+        if (cursor < value.length) {
+            parts.push({matched: false, text: value.slice(cursor)});
+        }
+
+        return parts;
+    }
+
+    function focusSearch(): void {
+        const input = document.getElementById("sidebar-settings-search") as HTMLInputElement | null;
+        if (!input) return;
+        input.focus();
+        input.select();
+    }
+
+    function getSearchResultHref(result: SearchResult): string {
+        const categoryRoute = resolve("/settings/[category]", {category: result.categoryId});
+        return `${categoryRoute}?setting=${result.settingId}&focus=${Date.now().toString()}`;
+    }
+
+    function activateSearchResult(index: number): void {
+        const target = document.getElementById(`search-result-${index.toString()}`) as HTMLAnchorElement | null;
+        if (!target) return;
+        target.click();
+    }
+
+    function handleWindowKeydown(event: KeyboardEvent): void {
+        if ((event.metaKey || event.ctrlKey) && event.key.toLocaleLowerCase() === "k") {
+            event.preventDefault();
+            focusSearch();
+        }
+    }
+
+    function handleSearchKeydown(event: KeyboardEvent): void {
+        if (!filteredSearchResults.length) return;
+
+        if (event.key === "ArrowDown") {
+            event.preventDefault();
+            selectedSearchIndex = (selectedSearchIndex + 1 + filteredSearchResults.length) % filteredSearchResults.length;
+            return;
+        }
+
+        if (event.key === "ArrowUp") {
+            event.preventDefault();
+            selectedSearchIndex = (selectedSearchIndex - 1 + filteredSearchResults.length) % filteredSearchResults.length;
+            return;
+        }
+
+        if (event.key === "Enter" && selectedSearchIndex >= 0) {
+            event.preventDefault();
+            activateSearchResult(selectedSearchIndex);
+            return;
+        }
+
+        if (event.key === "Escape") {
+            searchQuery = "";
+            selectedSearchIndex = -1;
+        }
+    }
+
+    function handleSearchInput(event: Event): void {
+        const input = event.currentTarget as HTMLInputElement;
+        searchQuery = input.value;
+        selectedSearchIndex = input.value.trim() ? 0 : -1;
+    }
+</script>
+
+<svelte:window onkeydown={handleWindowKeydown} />
+
+<div class="sidebar-search">
+    <input
+        id="sidebar-settings-search"
+        type="search"
+        class="search-input"
+        value={searchQuery}
+        oninput={handleSearchInput}
+        onkeydown={handleSearchKeydown}
+        placeholder="Search settings"
+        aria-label="Search settings"
+        autocomplete="off"
+        spellcheck={false}
+    />
+</div>
+
+<nav id="categories">
+    {#if normalizedSearchQuery}
+        <div id="search-results" role="listbox" aria-label="Search results">
+            {#if groupedSearchResults.length}
+                {#each groupedSearchResults as category (category.categoryId)}
+                    <section class="search-category">
+                        <Tab route={category.categoryRoute}>
+                            {#snippet icon()}
+                                {#if category.categoryId === "application"}
+                                    <img src={application} alt="Application Settings" />
+                                {:else if category.categoryId === "clipboard"}
+                                    <img src={clipboard} alt="Clipboard Settings" />
+                                {:else if category.categoryId === "window"}
+                                    <img src={windowIcon} alt="Window Settings" />
+                                {:else if category.categoryId === "colors"}
+                                    <img src={colors} alt="Color Settings" />
+                                {:else if category.categoryId === "fonts"}
+                                    <img src={fonts} alt="Font Settings" />
+                                {:else if category.categoryId === "keybinds"}
+                                    <img src={keybinds} alt="Keybind Settings" />
+                                {:else if category.categoryId === "mouse"}
+                                    <img src={mouse} alt="Mouse Settings" />
+                                {:else if category.categoryId === "gtk"}
+                                    <div class="icon-wrapper"><img src={gtk} alt="GTK Settings" /></div>
+                                {:else if category.categoryId === "linux"}
+                                    <img src={linux} alt="Linux Settings" />
+                                {:else if category.categoryId === "macos"}
+                                    <img src={macos} alt="macOS Settings" />
+                                {/if}
+                            {/snippet}
+                            {category.categoryName}
+                        </Tab>
+                        <div class="search-category-results">
+                            {#each category.results as result (result.routeKey)}
+                                <!-- eslint-disable-next-line svelte/no-navigation-without-resolve, svelte/first-attribute-linebreak -->
+                                <a href={getSearchResultHref(result)}
+                                    id={`search-result-${result.index.toString()}`}
+                                    class="search-result"
+                                    class:selected={result.index === selectedSearchIndex}
+                                    role="option"
+                                    aria-selected={result.index === selectedSearchIndex}
+                                    onmousemove={() => selectedSearchIndex = result.index}
+                                    onclick={() => {
+                                        searchQuery = "";
+                                        selectedSearchIndex = -1;
+                                    }}
+                                >
+                                    <span class="search-result-name">
+                                        {#each getHighlightParts(result.settingName, searchQuery) as part, i (`${result.routeKey}:name:${i.toString()}`)}
+                                            {#if part.matched}
+                                                <strong>{part.text}</strong>
+                                            {:else}
+                                                {part.text}
+                                            {/if}
+                                        {/each}
+                                    </span>
+                                    <span class="search-result-meta">
+                                        {#if result.groupName}
+                                            <span>
+                                                {#each getHighlightParts(result.groupName, searchQuery) as part, i (`${result.routeKey}:group:${i.toString()}`)}
+                                                    {#if part.matched}
+                                                        <strong>{part.text}</strong>
+                                                    {:else}
+                                                        {part.text}
+                                                    {/if}
+                                                {/each}
+                                            </span>
+                                        {/if}
+                                        {#if result.note}
+                                            <span>
+                                                {#each getHighlightParts(result.note, searchQuery) as part, i (`${result.routeKey}:note:${i.toString()}`)}
+                                                    {#if part.matched}
+                                                        <strong>{part.text}</strong>
+                                                    {:else}
+                                                        {part.text}
+                                                    {/if}
+                                                {/each}
+                                            </span>
+                                        {/if}
+                                    </span>
+                                </a>
+                            {/each}
+                        </div>
+                    </section>
+                {/each}
+            {:else}
+                <p class="search-empty">No settings match "{searchQuery.trim()}".</p>
+            {/if}
+        </div>
+    {:else}
+        {@render children()}
+    {/if}
+</nav>
+
+<style>
+.sidebar-search {
+    padding: 0 10px 8px 10px;
+}
+
+.search-input {
+    width: 100%;
+    border-radius: var(--radius-level-4);
+    border: 1px solid var(--border-level-1);
+    background: rgba(33, 30, 37, 0.8);
+    color: var(--font-color);
+    font-size: 0.9rem;
+    font-weight: 500;
+    padding: 8px 10px;
+    outline: none;
+}
+
+.search-input:focus {
+    border-color: var(--color-focus);
+    box-shadow: 0 0 0 2px rgba(102, 153, 255, 0.25);
+}
+
+#categories {
+    display: flex;
+    flex-direction: column;
+    flex: 1;
+    padding: 10px;
+    min-height: 0;
+    overflow: hidden;
+}
+
+#search-results {
+    display: flex;
+    flex-direction: column;
+    overflow-y: auto;
+    min-height: 0;
+    gap: 10px;
+}
+
+.search-empty {
+    margin: 0;
+    color: var(--font-color-muted);
+    font-size: 0.9rem;
+}
+
+.search-category {
+    display: flex;
+    flex-direction: column;
+    gap: 4px;
+}
+
+.search-category-results {
+    display: flex;
+    flex-direction: column;
+    gap: 3px;
+    margin-left: 10px;
+}
+
+.search-result {
+    display: flex;
+    flex-direction: column;
+    align-items: flex-start;
+    border: none;
+    background: transparent;
+    color: var(--font-color);
+    text-align: left;
+    padding: 6px;
+    border-radius: var(--radius-level-4);
+    gap: 2px;
+    text-decoration: none;
+}
+
+.search-result.selected,
+.search-result:hover {
+    background: var(--color-selected);
+}
+
+.search-result-name {
+    font-weight: 600;
+    font-size: 0.92rem;
+    line-height: 1.2;
+}
+
+.search-result-name :global(strong),
+.search-result-meta :global(strong) {
+    font-weight: 800;
+}
+
+.search-result-meta {
+    display: flex;
+    flex-direction: column;
+    color: var(--font-color-muted);
+    font-size: 0.78rem;
+    line-height: 1.2;
+    gap: 1px;
+}
+
+#categories img {
+    width: 100%;
+}
+
+#categories .icon-wrapper {
+    background: linear-gradient(#D3E3E9, #908F8C);
+    width: 20px;
+    height: 20px;
+    border-radius: var(--radius-level-4);
+    display: inline-flex;
+    justify-content: center;
+    align-items: center;
+}
+
+#categories .icon-wrapper img {
+    height: 14px;
+    width: 14px;
+}
+
+</style>

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -33,7 +33,7 @@
 
     function getSearchResultHref(result: SearchResult): string {
         const categoryRoute = resolve("/settings/[category]", {category: result.categoryId});
-        return `${categoryRoute}?setting=${result.settingId}&focus=${Date.now().toString()}`;
+        return `${categoryRoute}?setting=${result.settingId}`;
     }
 
     function activateSearchResult(index: number): void {
@@ -71,17 +71,13 @@
         }
 
         if (event.key === "Escape") {
-            searchState.query = "";
-            searchState.selectedIndex = -1;
-            searchState.activeIndex = -1;
+            setQuery("");
         }
     }
 
     function handleSearchInput(event: Event): void {
         const input = event.currentTarget as HTMLInputElement;
-        searchState.query = input.value;
-        searchState.selectedIndex = input.value.trim() ? 0 : -1;
-        searchState.activeIndex = -1;
+        setQuery(input.value);
     }
 
     // Scroll selected search result into view when it changes
@@ -174,7 +170,7 @@
                             {#each category.results as result (result.routeKey)}
                                 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve, svelte/first-attribute-linebreak -->
                                 <a href={getSearchResultHref(result)}
-                                    id={`search-result-${result.index.toString()}`}
+                                    id={`search-result-${result.index}`}
                                     class="search-result"
                                     class:active={result.index === searchState.activeIndex}
                                     class:selected={result.index === searchState.selectedIndex}
@@ -182,13 +178,12 @@
                                     aria-selected={result.index === searchState.selectedIndex}
                                     // onmousemove={() => searchState.selectedIndex = result.index}
                                     onclick={() => {
-                                        // searchState.query = "";
                                         searchState.selectedIndex = -1;
                                         searchState.activeIndex = result.index;
                                     }}
                                 >
                                     <span class="search-result-name">
-                                        {#each getHighlightParts(result.settingName) as part, i (`${result.routeKey}:name:${i.toString()}`)}
+                                        {#each getHighlightParts(result.settingName) as part, i (`${result.routeKey}:name:${i}`)}
                                             {#if part.matched}
                                                 <strong>{part.text}</strong>
                                             {:else}
@@ -199,7 +194,7 @@
                                     <span class="search-result-meta">
                                         {#if result.groupName}
                                             <span>
-                                                {#each getHighlightParts(result.groupName) as part, i (`${result.routeKey}:group:${i.toString()}`)}
+                                                {#each getHighlightParts(result.groupName) as part, i (`${result.routeKey}:group:${i}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}
@@ -210,7 +205,7 @@
                                         {/if}
                                         {#if result.note}
                                             <span>
-                                                {#each getHighlightParts(result.note) as part, i (`${result.routeKey}:note:${i.toString()}`)}
+                                                {#each getHighlightParts(result.note) as part, i (`${result.routeKey}:note:${i}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}
@@ -232,7 +227,7 @@
                         <path fill="currentColor" d="M23.957 41.77a18.02 18.02 0 0 0 10.477-3.376l11.109 11.11a2.66 2.66 0 0 0 1.898.773c1.524 0 2.625-1.172 2.625-2.672c0-.703-.234-1.359-.75-1.874L38.277 34.668c2.32-3.047 3.703-6.82 3.703-10.922c0-9.914-8.109-18.023-18.023-18.023c-9.937 0-18.023 8.109-18.023 18.023S14.02 41.77 23.957 41.77m0-3.891c-7.758 0-14.133-6.398-14.133-14.133S16.2 9.613 23.957 9.613c7.734 0 14.133 6.399 14.133 14.133c0 7.735-6.399 14.133-14.133 14.133" />
                     </svg>
                     <h2>No Results</h2>
-                    <p class="search-empty">No results for "{searchState.query.trim()}"</p>
+                    <p class="search-empty">No results for<span>"{searchState.query}"</span></p>
                 </div>
 
             {/if}
@@ -347,6 +342,15 @@
     margin: 0;
     color: var(--font-color-muted);
     font-size: 0.9rem;
+    display: inline-flex;
+    flex-wrap: wrap;
+    justify-content: center;
+    gap: 4px;
+}
+
+.search-empty span {
+    word-break: break-all;
+    text-align: center;
 }
 
 .search-category {

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -111,14 +111,12 @@
 
     // TODO: this is a bit janky, consider a more robust solution for keeping track of active/selected search results and their corresponding DOM elements
     // also move to search utility
-    function getHighlightParts(value: string, query: string): HighlightPart[] {
+    function getHighlightParts(value: string, queryOrTokens: string | string[]): HighlightPart[] {
         if (!value) return [];
 
-        const tokens = query
-            .trim()
-            .toLocaleLowerCase()
-            .split(/\s+/)
-            .filter(Boolean);
+        const tokens = Array.isArray(queryOrTokens)
+            ? queryOrTokens
+            : queryOrTokens.trim().toLocaleLowerCase().split(/\\s+/).filter(Boolean);
 
         if (!tokens.length) {
             return [{matched: false, text: value}];
@@ -127,6 +125,7 @@
         const lowerValue = value.toLocaleLowerCase();
         const ranges: Array<[number, number]> = [];
         for (const token of tokens) {
+            if (!token) continue;
             let fromIndex = 0;
             while (fromIndex < lowerValue.length) {
                 const index = lowerValue.indexOf(token, fromIndex);
@@ -202,13 +201,13 @@
 
         if (event.key === "ArrowDown") {
             event.preventDefault();
-            selectedSearchIndex = (selectedSearchIndex + 1 + filteredSearchResults.length) % filteredSearchResults.length;
+            selectedSearchIndex = selectedSearchIndex < filteredSearchResults.length - 1 ? selectedSearchIndex + 1 : 0;
             return;
         }
 
         if (event.key === "ArrowUp") {
             event.preventDefault();
-            selectedSearchIndex = (selectedSearchIndex - 1 + filteredSearchResults.length) % filteredSearchResults.length;
+            selectedSearchIndex = selectedSearchIndex > 0 ? selectedSearchIndex - 1 : filteredSearchResults.length - 1;
             return;
         }
 
@@ -337,7 +336,7 @@
                                     }}
                                 >
                                     <span class="search-result-name">
-                                        {#each getHighlightParts(result.settingName, searchQuery) as part, i (`${result.routeKey}:name:${i.toString()}`)}
+                                        {#each getHighlightParts(result.settingName, searchTokens) as part, i (`${result.routeKey}:name:${i.toString()}`)}
                                             {#if part.matched}
                                                 <strong>{part.text}</strong>
                                             {:else}
@@ -348,7 +347,7 @@
                                     <span class="search-result-meta">
                                         {#if result.groupName}
                                             <span>
-                                                {#each getHighlightParts(result.groupName, searchQuery) as part, i (`${result.routeKey}:group:${i.toString()}`)}
+                                                {#each getHighlightParts(result.groupName, searchTokens) as part, i (`${result.routeKey}:group:${i.toString()}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}
@@ -359,7 +358,7 @@
                                         {/if}
                                         {#if result.note}
                                             <span>
-                                                {#each getHighlightParts(result.note, searchQuery) as part, i (`${result.routeKey}:note:${i.toString()}`)}
+                                                {#each getHighlightParts(result.note, searchTokens) as part, i (`${result.routeKey}:note:${i.toString()}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -19,27 +19,46 @@
     import type {Snippet} from "svelte";
     import {scale} from "svelte/transition";
     import {getGroupedResults, getHighlightParts, getResults, hasGroupedResults, hasResults, searchState, setQuery, type SearchResult} from "$lib/stores/search.svelte";
+    import {goto} from "$app/navigation";
+    // import {goto} from "$app/navigation";
 
 
     const {children}: {children: Snippet} = $props();
 
 
+    let inputElement: HTMLInputElement | null = null;
     function focusSearch(): void {
-        const input = document.getElementById("sidebar-settings-search") as HTMLInputElement | null;
-        if (!input) return;
-        input.focus();
-        input.select();
+        if (!inputElement) return;
+        inputElement.focus();
+        inputElement.select();
     }
 
     function getSearchResultHref(result: SearchResult): string {
-        const categoryRoute = resolve("/settings/[category]", {category: result.categoryId});
-        return `${categoryRoute}?setting=${result.settingId}`;
+        return resolve("/settings/[category]", {category: result.categoryId});
     }
 
-    function activateSearchResult(index: number): void {
-        const target = document.getElementById(`search-result-${index.toString()}`) as HTMLAnchorElement | null;
-        if (!target) return;
-        target.click();
+    function activateSearchResult(event: MouseEvent | KeyboardEvent, result: SearchResult): void {
+        const href = getSearchResultHref(result);
+        const isSamePage = location.pathname === href;
+
+        // If clicking on the already selected search result, retrigger the scroll and highlight effect by clearing and re-setting the selectedId
+        if (isSamePage && searchState.selectedId === result.settingId) searchState.selectedId = "";
+        searchState.selectedId = result.settingId;
+
+        // Don't navigate if we're already on the page, just set the selectedId so the item can scroll into view and highlight
+        if (isSamePage) return event.preventDefault();
+
+        // Let the link handle navigation for clicks to preserve things like ctrl+click to open in new tab
+        if (event.type === "click") return;
+
+        // Keyboard event needs special handling to navigate and then focus search input again for continued keyboard navigation
+        if (event.type === "keydown") {
+            // eslint-disable-next-line svelte/no-navigation-without-resolve, svelte/no-goto-without-base
+            void goto(href).then(() => {
+                // Refocus search after navigation so user can continue navigating with keyboard
+                focusSearch();
+            });
+        }
     }
 
     function handleWindowKeydown(event: KeyboardEvent): void {
@@ -66,7 +85,7 @@
 
         if (event.key === "Enter" && searchState.selectedIndex >= 0) {
             event.preventDefault();
-            activateSearchResult(searchState.selectedIndex);
+            activateSearchResult(event, getResults()[searchState.selectedIndex]);
             return;
         }
 
@@ -108,6 +127,7 @@
         aria-label="Search"
         autocomplete="off"
         spellcheck={false}
+        bind:this={inputElement}
     />
 
     {#if searchState.query}
@@ -137,6 +157,7 @@
                         <Tab
                             route={category.categoryRoute}
                             onClick={() => {
+                                searchState.selectedId = "";
                                 searchState.activeIndex = -1; // tab selection is inside component for now
                             }}
                         >
@@ -176,8 +197,8 @@
                                     class:selected={result.index === searchState.selectedIndex}
                                     role="option"
                                     aria-selected={result.index === searchState.selectedIndex}
-                                    // onmousemove={() => searchState.selectedIndex = result.index}
-                                    onclick={() => {
+                                    onclick={(event) => {
+                                        activateSearchResult(event, result);
                                         searchState.selectedIndex = -1;
                                         searchState.activeIndex = result.index;
                                     }}

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -20,7 +20,7 @@
     import {scale} from "svelte/transition";
     import {getGroupedResults, getHighlightParts, getResults, hasGroupedResults, hasResults, searchState, setQuery, type SearchResult} from "$lib/stores/search.svelte";
     import {goto} from "$app/navigation";
-    // import {goto} from "$app/navigation";
+    import {page} from "$app/state";
 
 
     const {children}: {children: Snippet} = $props();
@@ -42,7 +42,7 @@
         if (isModifiedClick) return;
 
         const href = getSearchResultHref(result);
-        const isSamePage = location.pathname === href;
+        const isSamePage = page.url.pathname === href;
 
         // If clicking on the already selected search result, retrigger the scroll and highlight effect by clearing and re-setting the selectedId
         if (isSamePage && searchState.selectedId === result.settingId) searchState.selectedId = "";
@@ -165,6 +165,7 @@
                     <section class="search-category">
                         <Tab
                             route={category.categoryRoute}
+                            selected={page.url.pathname === category.categoryRoute && searchState.selectedId === ""}
                             onClick={() => {
                                 searchState.selectedId = "";
                                 searchState.activeIndex = -1; // tab selection is inside component for now

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -1,7 +1,6 @@
 <script lang="ts">
     import {resolve} from "$app/paths";
     import Tab from "$lib/components/Tab.svelte";
-    import settings from "$lib/data/settings";
 
     import application from "$lib/images/tabs/application.webp";
     import clipboard from "$lib/images/tabs/clipboard.webp";
@@ -19,157 +18,11 @@
 
     import type {Snippet} from "svelte";
     import {scale} from "svelte/transition";
+    import {getGroupedResults, getHighlightParts, getResults, hasGroupedResults, hasResults, searchState, setQuery, type SearchResult} from "$lib/stores/search.svelte";
 
-
-    interface SearchResult {
-        categoryId: string;
-        categoryName: string;
-        groupName: string;
-        note: string;
-        routeKey: string;
-        settingId: string;
-        settingName: string;
-        searchableText: string;
-    }
-
-    interface HighlightPart {
-        matched: boolean;
-        text: string;
-    }
 
     const {children}: {children: Snippet} = $props();
 
-    // TODO: this is pretty expensive to compute on every keystroke, consider precomputing and caching searchableText in the settings data
-    const searchableSettings = $derived.by(() => {
-        const results: SearchResult[] = [];
-        for (const category of settings) {
-            for (const group of category.groups) {
-                for (const setting of group.settings) {
-                    const searchableText = [
-                        category.name,
-                        group.name,
-                        setting.name,
-                        setting.note ?? ""
-                    ]
-                        .join(" ")
-                        .toLocaleLowerCase();
-                    results.push({
-                        categoryId: category.id,
-                        categoryName: category.name,
-                        groupName: group.name,
-                        note: setting.note ?? "",
-                        routeKey: `${category.id}:${setting.id}`,
-                        settingId: setting.id,
-                        settingName: setting.name,
-                        searchableText,
-                    });
-                }
-            }
-        }
-        return results;
-    });
-
-    let searchQuery = $state("");
-    let selectedSearchIndex = $state(-1);
-    let activeSearchIndex = $state(-1);
-
-    const normalizedSearchQuery = $derived(searchQuery.trim().toLocaleLowerCase());
-    const searchTokens = $derived(normalizedSearchQuery.split(/\s+/).filter(Boolean));
-
-    const filteredSearchResults = $derived.by(() => {
-        if (!searchTokens.length) return [];
-        return searchableSettings.filter(result => searchTokens.every(token => result.searchableText.includes(token)));
-    });
-
-    // TODO: this grouping is also a bit expensive, consider memoizing based on the filtered results
-    // also move grouping logic to a utility function
-    const groupedSearchResults = $derived.by(() => {
-        const grouped: Array<{
-            categoryId: string;
-            categoryName: string;
-            categoryRoute: string;
-            results: Array<SearchResult & {index: number}>;
-        }> = [];
-
-        filteredSearchResults.forEach((result, index) => {
-            const existing = grouped.find(group => group.categoryId === result.categoryId);
-            if (existing) {
-                existing.results.push({...result, index});
-                return;
-            }
-
-            grouped.push({
-                categoryId: result.categoryId,
-                categoryName: result.categoryName,
-                categoryRoute: resolve("/settings/[category]", {category: result.categoryId}),
-                results: [{...result, index}],
-            });
-        });
-
-        return grouped;
-    });
-
-    // TODO: this is a bit janky, consider a more robust solution for keeping track of active/selected search results and their corresponding DOM elements
-    // also move to search utility
-    function getHighlightParts(value: string, queryOrTokens: string | string[]): HighlightPart[] {
-        if (!value) return [];
-
-        const tokens = Array.isArray(queryOrTokens)
-            ? queryOrTokens
-            : queryOrTokens.trim().toLocaleLowerCase().split(/\\s+/).filter(Boolean);
-
-        if (!tokens.length) {
-            return [{matched: false, text: value}];
-        }
-
-        const lowerValue = value.toLocaleLowerCase();
-        const ranges: Array<[number, number]> = [];
-        for (const token of tokens) {
-            if (!token) continue;
-            let fromIndex = 0;
-            while (fromIndex < lowerValue.length) {
-                const index = lowerValue.indexOf(token, fromIndex);
-                if (index < 0) break;
-
-                ranges.push([index, index + token.length]);
-                fromIndex = index + token.length;
-            }
-        }
-
-        if (!ranges.length) {
-            return [{matched: false, text: value}];
-        }
-
-        ranges.sort((a, b) => a[0] - b[0]);
-
-        const merged: Array<[number, number]> = [ranges[0]];
-        for (let i = 1; i < ranges.length; i++) {
-            const range = ranges[i];
-            const last = merged[merged.length - 1];
-            if (range[0] <= last[1]) {
-                last[1] = Math.max(last[1], range[1]);
-            }
-            else {
-                merged.push(range);
-            }
-        }
-
-        const parts: HighlightPart[] = [];
-        let cursor = 0;
-        for (const [start, end] of merged) {
-            if (start > cursor) {
-                parts.push({matched: false, text: value.slice(cursor, start)});
-            }
-            parts.push({matched: true, text: value.slice(start, end)});
-            cursor = end;
-        }
-
-        if (cursor < value.length) {
-            parts.push({matched: false, text: value.slice(cursor)});
-        }
-
-        return parts;
-    }
 
     function focusSearch(): void {
         const input = document.getElementById("sidebar-settings-search") as HTMLInputElement | null;
@@ -197,43 +50,44 @@
     }
 
     function handleSearchKeydown(event: KeyboardEvent): void {
-        if (!filteredSearchResults.length) return;
+        if (!hasResults()) return;
 
         if (event.key === "ArrowDown") {
             event.preventDefault();
-            selectedSearchIndex = selectedSearchIndex < filteredSearchResults.length - 1 ? selectedSearchIndex + 1 : 0;
+            searchState.selectedIndex = searchState.selectedIndex < getResults().length - 1 ? searchState.selectedIndex + 1 : 0;
             return;
         }
 
         if (event.key === "ArrowUp") {
             event.preventDefault();
-            selectedSearchIndex = selectedSearchIndex > 0 ? selectedSearchIndex - 1 : filteredSearchResults.length - 1;
+            searchState.selectedIndex = searchState.selectedIndex > 0 ? searchState.selectedIndex - 1 : getResults().length - 1;
             return;
         }
 
-        if (event.key === "Enter" && selectedSearchIndex >= 0) {
+        if (event.key === "Enter" && searchState.selectedIndex >= 0) {
             event.preventDefault();
-            activateSearchResult(selectedSearchIndex);
+            activateSearchResult(searchState.selectedIndex);
             return;
         }
 
         if (event.key === "Escape") {
-            searchQuery = "";
-            selectedSearchIndex = -1;
+            searchState.query = "";
+            searchState.selectedIndex = -1;
+            searchState.activeIndex = -1;
         }
     }
 
     function handleSearchInput(event: Event): void {
         const input = event.currentTarget as HTMLInputElement;
-        searchQuery = input.value;
-        selectedSearchIndex = input.value.trim() ? 0 : -1;
-        activeSearchIndex = -1;
+        searchState.query = input.value;
+        searchState.selectedIndex = input.value.trim() ? 0 : -1;
+        searchState.activeIndex = -1;
     }
 
     // Scroll selected search result into view when it changes
     $effect(() => {
-        if (selectedSearchIndex < 0) return;
-        const target = document.getElementById(`search-result-${selectedSearchIndex.toString()}`) as HTMLAnchorElement | null;
+        if (searchState.selectedIndex < 0) return;
+        const target = document.getElementById(`search-result-${searchState.selectedIndex.toString()}`) as HTMLAnchorElement | null;
         if (!target) return;
         target.scrollIntoView({block: "nearest"});
     });
@@ -251,7 +105,7 @@
         id="sidebar-settings-search"
         type="search"
         class="search-input"
-        value={searchQuery}
+        value={searchState.query}
         oninput={handleSearchInput}
         onkeydown={handleSearchKeydown}
         placeholder="Search"
@@ -260,16 +114,14 @@
         spellcheck={false}
     />
 
-    {#if normalizedSearchQuery}
+    {#if searchState.query}
         <button
             class="search-clear-button"
             type="button"
             title="Clear search"
             transition:scale={{duration: 150}}
             onclick={() => {
-                searchQuery = "";
-                selectedSearchIndex = -1;
-                activeSearchIndex = -1;
+                setQuery("");
             }}
         >
             <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
@@ -281,15 +133,15 @@
 </div>
 
 <nav id="categories">
-    {#if normalizedSearchQuery}
+    {#if searchState.query}
         <div id="search-results" role="listbox" aria-label="Search results">
-            {#if groupedSearchResults.length}
-                {#each groupedSearchResults as category (category.categoryId)}
+            {#if hasGroupedResults()}
+                {#each getGroupedResults() as category (category.categoryId)}
                     <section class="search-category">
                         <Tab
                             route={category.categoryRoute}
                             onClick={() => {
-                                activeSearchIndex = -1; // tab selection is inside component for now
+                                searchState.activeIndex = -1; // tab selection is inside component for now
                             }}
                         >
                             <!-- TODO: a lot of de-duping with the main sidebar -->
@@ -324,19 +176,19 @@
                                 <a href={getSearchResultHref(result)}
                                     id={`search-result-${result.index.toString()}`}
                                     class="search-result"
-                                    class:active={result.index === activeSearchIndex}
-                                    class:selected={result.index === selectedSearchIndex}
+                                    class:active={result.index === searchState.activeIndex}
+                                    class:selected={result.index === searchState.selectedIndex}
                                     role="option"
-                                    aria-selected={result.index === selectedSearchIndex}
-                                    // onmousemove={() => selectedSearchIndex = result.index}
+                                    aria-selected={result.index === searchState.selectedIndex}
+                                    // onmousemove={() => searchState.selectedIndex = result.index}
                                     onclick={() => {
-                                        // searchQuery = "";
-                                        selectedSearchIndex = -1;
-                                        activeSearchIndex = result.index;
+                                        // searchState.query = "";
+                                        searchState.selectedIndex = -1;
+                                        searchState.activeIndex = result.index;
                                     }}
                                 >
                                     <span class="search-result-name">
-                                        {#each getHighlightParts(result.settingName, searchTokens) as part, i (`${result.routeKey}:name:${i.toString()}`)}
+                                        {#each getHighlightParts(result.settingName) as part, i (`${result.routeKey}:name:${i.toString()}`)}
                                             {#if part.matched}
                                                 <strong>{part.text}</strong>
                                             {:else}
@@ -347,7 +199,7 @@
                                     <span class="search-result-meta">
                                         {#if result.groupName}
                                             <span>
-                                                {#each getHighlightParts(result.groupName, searchTokens) as part, i (`${result.routeKey}:group:${i.toString()}`)}
+                                                {#each getHighlightParts(result.groupName) as part, i (`${result.routeKey}:group:${i.toString()}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}
@@ -358,7 +210,7 @@
                                         {/if}
                                         {#if result.note}
                                             <span>
-                                                {#each getHighlightParts(result.note, searchTokens) as part, i (`${result.routeKey}:note:${i.toString()}`)}
+                                                {#each getHighlightParts(result.note) as part, i (`${result.routeKey}:note:${i.toString()}`)}
                                                     {#if part.matched}
                                                         <strong>{part.text}</strong>
                                                     {:else}
@@ -380,7 +232,7 @@
                         <path fill="currentColor" d="M23.957 41.77a18.02 18.02 0 0 0 10.477-3.376l11.109 11.11a2.66 2.66 0 0 0 1.898.773c1.524 0 2.625-1.172 2.625-2.672c0-.703-.234-1.359-.75-1.874L38.277 34.668c2.32-3.047 3.703-6.82 3.703-10.922c0-9.914-8.109-18.023-18.023-18.023c-9.937 0-18.023 8.109-18.023 18.023S14.02 41.77 23.957 41.77m0-3.891c-7.758 0-14.133-6.398-14.133-14.133S16.2 9.613 23.957 9.613c7.734 0 14.133 6.399 14.133 14.133c0 7.735-6.399 14.133-14.133 14.133" />
                     </svg>
                     <h2>No Results</h2>
-                    <p class="search-empty">No results for "{searchQuery.trim()}"</p>
+                    <p class="search-empty">No results for "{searchState.query.trim()}"</p>
                 </div>
 
             {/if}

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -226,6 +226,11 @@
 <svelte:window onkeydown={handleWindowKeydown} />
 
 <div class="sidebar-search">
+    <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56" class="search-icon">
+        <path d="M0 0h56v56H0z" fill="none" />
+        <path fill="currentColor" d="M23.957 41.77a18.02 18.02 0 0 0 10.477-3.376l11.109 11.11a2.66 2.66 0 0 0 1.898.773c1.524 0 2.625-1.172 2.625-2.672c0-.703-.234-1.359-.75-1.874L38.277 34.668c2.32-3.047 3.703-6.82 3.703-10.922c0-9.914-8.109-18.023-18.023-18.023c-9.937 0-18.023 8.109-18.023 18.023S14.02 41.77 23.957 41.77m0-3.891c-7.758 0-14.133-6.398-14.133-14.133S16.2 9.613 23.957 9.613c7.734 0 14.133 6.399 14.133 14.133c0 7.735-6.399 14.133-14.133 14.133" />
+    </svg>
+
     <input
         id="sidebar-settings-search"
         type="search"
@@ -233,11 +238,28 @@
         value={searchQuery}
         oninput={handleSearchInput}
         onkeydown={handleSearchKeydown}
-        placeholder="Search settings"
-        aria-label="Search settings"
+        placeholder="Search"
+        aria-label="Search"
         autocomplete="off"
         spellcheck={false}
     />
+
+    {#if normalizedSearchQuery}
+        <button
+            class="search-clear-button"
+            type="button"
+            title="Clear search"
+            onclick={() => {
+                searchQuery = "";
+                selectedSearchIndex = -1;
+            }}
+        >
+            <svg xmlns="http://www.w3.org/2000/svg" width="1em" height="1em" viewBox="0 0 56 56">
+                <path d="M0 0h56v56H0z" fill="none" />
+                <path fill="currentColor" d="M28 51.906c13.055 0 23.906-10.828 23.906-23.906c0-13.055-10.875-23.906-23.93-23.906C14.899 4.094 4.095 14.945 4.095 28c0 13.078 10.828 23.906 23.906 23.906m-8.414-13.5a1.99 1.99 0 0 1-1.992-1.992c0-.539.234-1.008.609-1.36l6.984-7.03l-6.984-7.032a1.8 1.8 0 0 1-.61-1.36c0-1.077.891-1.945 1.993-1.945c.539 0 1.008.211 1.36.586l7.03 7.008l7.079-7.031c.398-.422.82-.61 1.336-.61c1.101 0 1.992.891 1.992 1.97c0 .538-.188.984-.586 1.359l-7.031 7.054l7.007 6.985c.352.375.586.844.586 1.406a1.99 1.99 0 0 1-1.992 1.992a1.93 1.93 0 0 1-1.383-.586l-7.007-7.031l-6.985 7.031a1.93 1.93 0 0 1-1.406.586" />
+            </svg>
+        </button>
+    {/if}
 </div>
 
 <nav id="categories">
@@ -336,24 +358,62 @@
 
 <style>
 .sidebar-search {
-    padding: 0 10px 8px 10px;
+    --search-height: 16px;
+
+    display: flex;
+    align-items: center;
+    gap: 6px;
+    padding: 8px;
+    margin: 0 10px 4px;
+    border-radius: var(--radius-level-4);
+    background: rgba(255, 255, 255, 0.075);
+    box-shadow:
+        inset 0px 2px 1px -3px rgba(255, 255, 255, 0.65),
+        inset 0px -3px 1px -3px rgba(255, 255, 255, 0.65);
+}
+
+.sidebar-search:has(.search-input:focus) {
+    outline: var(--border-input-focus);
+}
+
+.search-icon {
+    color: currentColor;
+    height: var(--search-height);
+    width: var(--search-height);
 }
 
 .search-input {
     width: 100%;
-    border-radius: var(--radius-level-4);
-    border: 1px solid var(--border-level-1);
-    background: rgba(33, 30, 37, 0.8);
+    flex: 1;
+    border: 0;
+    background: transparent;
     color: var(--font-color);
     font-size: 0.9rem;
     font-weight: 500;
-    padding: 8px 10px;
     outline: none;
+    height: var(--search-height);
 }
 
 .search-input:focus {
-    border-color: var(--color-focus);
-    box-shadow: 0 0 0 2px rgba(102, 153, 255, 0.25);
+    /* Focus border is handled by container */
+    outline: 0;
+}
+
+.search-clear-button {
+    border: none;
+    background: transparent;
+    color: var(--font-color);
+    padding: 0;
+    height: var(--search-height);
+    width: var(--search-height);
+    border-radius: var(--radius-level-4);
+    display: flex;
+    justify-content: center;
+    align-items: center;
+}
+
+.search-clear-button:hover {
+    background: none;
 }
 
 #categories {

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -48,8 +48,9 @@
         if (isSamePage && searchState.selectedId === result.settingId) searchState.selectedId = "";
         searchState.selectedId = result.settingId;
 
+        // Set both selectedIndex and activeIndex to keep keyboard and click selection in sync
         if (result.index !== undefined) {
-            searchState.selectedIndex = -1;
+            searchState.selectedIndex = result.index;
             searchState.activeIndex = result.index;
         }
 

--- a/src/lib/components/SettingsSearch.svelte
+++ b/src/lib/components/SettingsSearch.svelte
@@ -37,13 +37,21 @@
         return resolve("/settings/[category]", {category: result.categoryId});
     }
 
-    function activateSearchResult(event: MouseEvent | KeyboardEvent, result: SearchResult): void {
+    function activateSearchResult(event: MouseEvent | KeyboardEvent, result: SearchResult & {index?: number}): void {
+        const isModifiedClick = event instanceof MouseEvent && (event.metaKey || event.ctrlKey || event.shiftKey || event.button === 1);
+        if (isModifiedClick) return;
+
         const href = getSearchResultHref(result);
         const isSamePage = location.pathname === href;
 
         // If clicking on the already selected search result, retrigger the scroll and highlight effect by clearing and re-setting the selectedId
         if (isSamePage && searchState.selectedId === result.settingId) searchState.selectedId = "";
         searchState.selectedId = result.settingId;
+
+        if (result.index !== undefined) {
+            searchState.selectedIndex = -1;
+            searchState.activeIndex = result.index;
+        }
 
         // Don't navigate if we're already on the page, just set the selectedId so the item can scroll into view and highlight
         if (isSamePage) return event.preventDefault();
@@ -85,7 +93,7 @@
 
         if (event.key === "Enter" && searchState.selectedIndex >= 0) {
             event.preventDefault();
-            activateSearchResult(event, getResults()[searchState.selectedIndex]);
+            activateSearchResult(event, {...getResults()[searchState.selectedIndex], index: searchState.selectedIndex});
             return;
         }
 
@@ -199,8 +207,6 @@
                                     aria-selected={result.index === searchState.selectedIndex}
                                     onclick={(event) => {
                                         activateSearchResult(event, result);
-                                        searchState.selectedIndex = -1;
-                                        searchState.activeIndex = result.index;
                                     }}
                                 >
                                     <span class="search-result-name">

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,5 +1,6 @@
 <script lang="ts">
     import {page} from "$app/state";
+    import {searchState} from "$lib/stores/search.svelte";
     import type {Snippet} from "svelte";
 
 
@@ -16,7 +17,7 @@
     const target = $derived(isExternal ? "_blank" : "");
     const rel = $derived(isExternal ? "noopener noreferrer" : "");
 
-    const selected = $derived(path === route && page.url.search === "");
+    const selected = $derived(path === route && (page.url.search === "" || searchState.query === ""));
 </script>
 
 

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -17,7 +17,7 @@
     const target = $derived(isExternal ? "_blank" : "");
     const rel = $derived(isExternal ? "noopener noreferrer" : "");
 
-    const selected = $derived(path === route && (page.url.search === "" || searchState.query === ""));
+    const selected = $derived(path === route && (searchState.selectedId === ""));
 </script>
 
 

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -1,6 +1,5 @@
 <script lang="ts">
     import {page} from "$app/state";
-    import {searchState} from "$lib/stores/search.svelte";
     import type {Snippet} from "svelte";
 
 
@@ -9,15 +8,16 @@
         icon: Snippet;
         route?: string;
         onClick?: (e: MouseEvent) => void;
+        selected?: boolean; // for external control (e.g. search)
     }
-    const {children, icon, route = "", onClick}: Props = $props();
+    const {children, icon, route = "", onClick, selected}: Props = $props();
     const path = $derived(page.url.pathname);
 
     const isExternal = $derived(route.startsWith("http"));
     const target = $derived(isExternal ? "_blank" : "");
     const rel = $derived(isExternal ? "noopener noreferrer" : "");
 
-    const selected = $derived(path === route && (searchState.selectedId === ""));
+    const isSelected = $derived(selected ?? (path === route));
 </script>
 
 
@@ -25,7 +25,7 @@
 <!-- eslint-disable-next-line svelte/no-navigation-without-resolve, svelte/first-attribute-linebreak -->
 <a href={route}
     class="nav-tab"
-    class:selected
+    class:selected={isSelected}
     {target}
     {rel}
     onclick={onClick}

--- a/src/lib/components/Tab.svelte
+++ b/src/lib/components/Tab.svelte
@@ -7,15 +7,16 @@
         children: Snippet;
         icon: Snippet;
         route?: string;
+        onClick?: (e: MouseEvent) => void;
     }
-    const {children, icon, route = ""}: Props = $props();
+    const {children, icon, route = "", onClick}: Props = $props();
     const path = $derived(page.url.pathname);
 
     const isExternal = $derived(route.startsWith("http"));
     const target = $derived(isExternal ? "_blank" : "");
     const rel = $derived(isExternal ? "noopener noreferrer" : "");
 
-    const selected = $derived(path === route);
+    const selected = $derived(path === route && page.url.search === "");
 </script>
 
 
@@ -26,6 +27,7 @@
     class:selected
     {target}
     {rel}
+    onclick={onClick}
 >
     <div class="tab-icon">{@render icon()}</div>
     <div class="tab-label">{@render children()}</div>

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,10 +1,10 @@
 <script lang="ts">
-    import {tick, type Snippet} from "svelte";
+    import {type Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
     import {alert} from "$lib/stores/modals.svelte";
     import Badge from "../Badge.svelte";
-    import {page} from "$app/state";
+    import {searchState} from "$lib/stores/search.svelte";
 
     interface Props {
         name?: string;
@@ -56,31 +56,25 @@
 
     let itemElement: HTMLElement | null = null;
     let shouldHighlight = $state(false);
-    const targetId = $derived(page.url.searchParams.get("setting") || undefined);
     $effect(() => {
-        if (!settingId || !itemElement) return;
-        if (settingId !== targetId) return;
+        if (!searchState.selectedId || !itemElement) return;
+        if (searchState.selectedId !== settingId) return;
 
         const settingEl = itemElement;
         if (!settingEl) return;
 
-        // let timeout: number | null = null;
         let cancelled = false;
 
         // Flash the setting item to draw attention to it
         requestAnimationFrame(() => {
             if (cancelled) return;
+            // eslint-disable-next-line @typescript-eslint/no-unsafe-call
             settingEl.scrollIntoView({behavior: "smooth", block: "center"});
             shouldHighlight = true;
-            // onanimationend will reset shouldHighlight to false
-            // timeout = window.setTimeout(() => {
-            //     shouldHighlight = false;
-            // }, 2000);
         });
         return () => {
             cancelled = true;
             shouldHighlight = false;
-            // if (timeout) window.clearTimeout(timeout);
         };
     });
 </script>

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -128,6 +128,7 @@
     right: -12px;
     bottom: -12px;
     animation: flash-highlight 2s ease-in-out;
+    pointer-events: none;
 }
 
 .setting-item:global(.flash-highlight):first-child::before {

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -84,7 +84,10 @@
     data-setting-id={settingId || undefined}
     bind:this={itemElement}
     class:flash-highlight={shouldHighlight}
-    onanimationend={() => shouldHighlight = false}
+    onanimationend={() => {
+        shouldHighlight = false;
+        if (searchState.selectedId === settingId) searchState.selectedId = "";
+    }}
 >
     <div class="row">
         {#if name}

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -84,10 +84,7 @@
     data-setting-id={settingId || undefined}
     bind:this={itemElement}
     class:flash-highlight={shouldHighlight}
-    onanimationend={() => {
-        shouldHighlight = false;
-        if (searchState.selectedId === settingId) searchState.selectedId = "";
-    }}
+    onanimationend={() => shouldHighlight = false}
 >
     <div class="row">
         {#if name}

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -1,9 +1,10 @@
 <script lang="ts">
-    import {type Snippet} from "svelte";
+    import {tick, type Snippet} from "svelte";
     import {createTooltipAttachment} from "$lib/attachments/tooltip";
     import type {GhosttyPlatform} from "$lib/data/ghostty-schema";
     import {alert} from "$lib/stores/modals.svelte";
     import Badge from "../Badge.svelte";
+    import {page} from "$app/state";
 
     interface Props {
         name?: string;
@@ -52,9 +53,45 @@
         if (badge.type === "version") return `Added in Ghostty v${since}`;
         return "";
     };
+
+    let itemElement: HTMLElement | null = null;
+    let shouldHighlight = $state(false);
+    const targetId = $derived(page.url.searchParams.get("setting") || undefined);
+    $effect(() => {
+        if (!settingId || !itemElement) return;
+        if (settingId !== targetId) return;
+
+        const settingEl = itemElement;
+        if (!settingEl) return;
+
+        // let timeout: number | null = null;
+        let cancelled = false;
+
+        // Flash the setting item to draw attention to it
+        requestAnimationFrame(() => {
+            if (cancelled) return;
+            settingEl.scrollIntoView({behavior: "smooth", block: "center"});
+            shouldHighlight = true;
+            // onanimationend will reset shouldHighlight to false
+            // timeout = window.setTimeout(() => {
+            //     shouldHighlight = false;
+            // }, 2000);
+        });
+        return () => {
+            cancelled = true;
+            shouldHighlight = false;
+            // if (timeout) window.clearTimeout(timeout);
+        };
+    });
 </script>
 
-<div class="setting-item" data-setting-id={settingId || undefined}>
+<div
+    class="setting-item"
+    data-setting-id={settingId || undefined}
+    bind:this={itemElement}
+    class:flash-highlight={shouldHighlight}
+    onanimationend={() => shouldHighlight = false}
+>
     <div class="row">
         {#if name}
         <div class="row-left">

--- a/src/lib/components/settings/Item.svelte
+++ b/src/lib/components/settings/Item.svelte
@@ -11,12 +11,13 @@
         platform?: GhosttyPlatform[];
         since?: string;
         schemaDescription?: string;
+        settingId?: string; // for search reference
         children: Snippet;
         onReset?: () => void;
         isNonDefault?: boolean;
     }
 
-    const {name = "", note = "", platform, since, schemaDescription, children, onReset, isNonDefault = false}: Props = $props();
+    const {name = "", note = "", platform, since, schemaDescription, settingId, children, onReset, isNonDefault = false}: Props = $props();
     const tooltipAttachment = createTooltipAttachment("Reset to default");
 
 
@@ -53,7 +54,7 @@
     };
 </script>
 
-<div class="setting-item">
+<div class="setting-item" data-setting-id={settingId || undefined}>
     <div class="row">
         {#if name}
         <div class="row-left">
@@ -111,6 +112,30 @@
     display: flex;
     flex-direction: column;
     gap: 5px;
+    /* width: 100%; */
+    /* box-sizing: border-box; */
+    /* padding: 4px 8px; */
+    /* margin: -4px -8px; */
+    position: relative;
+}
+
+.setting-item:global(.flash-highlight)::before {
+    content: "";
+    position: absolute;
+    /* group padding size */
+    top: -12px;
+    left: -12px;
+    right: -12px;
+    bottom: -12px;
+    animation: flash-highlight 2s ease-in-out;
+}
+
+.setting-item:global(.flash-highlight):first-child::before {
+    border-radius: var(--radius-level-4) var(--radius-level-4) 0 0;
+}
+
+.setting-item:global(.flash-highlight):last-child::before {
+    border-radius: 0 0 var(--radius-level-4) var(--radius-level-4);
 }
 
 .setting-item .row {
@@ -225,5 +250,17 @@
     box-shadow:
         0 0 1px -1px rgba(0,0,0,0.7),
         0 0 1px white inset;
+}
+
+@keyframes flash-highlight {
+    0% {
+        background: rgba(128, 199, 255, 0.45);
+        box-shadow: 0 0 0 1px rgba(152, 217, 255, 0.6);
+    }
+
+    100% {
+        background: transparent;
+        box-shadow: 0 0 0 1px rgba(152, 217, 255, 0);
+    }
 }
 </style>

--- a/src/lib/stores/search.svelte.ts
+++ b/src/lib/stores/search.svelte.ts
@@ -91,7 +91,7 @@ const stripHtmlRegex = (html: string) => html.replace(/<[^>]*>/g, "");
 // TODO: this is pretty inefficient, we should probably build an index for this instead
 // of doing a linear search through all settings every time. However, it is unlikely that
 // there will be enough settings to cause performance issues, so this is good enough for now.
-const searchableSettings = $derived.by(() => {
+const searchableSettings = (() => {
     const results: SearchResult[] = [];
     for (const category of settings) {
         for (const group of category.groups) {
@@ -113,7 +113,7 @@ const searchableSettings = $derived.by(() => {
         }
     }
     return results;
-});
+})();
 
 
 export interface HighlightPart {

--- a/src/lib/stores/search.svelte.ts
+++ b/src/lib/stores/search.svelte.ts
@@ -9,13 +9,13 @@ import settings from "$lib/data/settings";
 
 export const searchState = $state({
     query: "",
-    selectedIndex: 0,
-    activeIndex: 0,
+    selectedIndex: -1,
+    activeIndex: -1,
 });
 
 export function setQuery(query: string) {
     searchState.query = query.trim().toLocaleLowerCase(); // Normalize on setting query to avoid doing it repeatedly in derived stores
-    searchState.selectedIndex = -1;
+    searchState.selectedIndex = searchState.query ? 0 : -1;
     searchState.activeIndex = -1;
 }
 

--- a/src/lib/stores/search.svelte.ts
+++ b/src/lib/stores/search.svelte.ts
@@ -11,12 +11,14 @@ export const searchState = $state({
     query: "",
     selectedIndex: -1,
     activeIndex: -1,
+    selectedId: "",
 });
 
 export function setQuery(query: string) {
     searchState.query = query.trim().toLocaleLowerCase(); // Normalize on setting query to avoid doing it repeatedly in derived stores
     searchState.selectedIndex = searchState.query ? 0 : -1;
     searchState.activeIndex = -1;
+    searchState.selectedId = "";
 }
 
 const searchTokens = $derived.by(() => searchState.query.split(/\s+/).filter(Boolean));

--- a/src/lib/stores/search.svelte.ts
+++ b/src/lib/stores/search.svelte.ts
@@ -1,0 +1,180 @@
+import {resolve} from "$app/paths";
+import settings from "$lib/data/settings";
+
+
+// FIXME: this is a bit of a mess, now that we separated this logic from the UI,
+// consider refactoring this to be more maintainable and testable. Also consider
+// implementing a more robust search algorithm, such as fuzzy search, to improve
+// search results.
+
+export const searchState = $state({
+    query: "",
+    selectedIndex: 0,
+    activeIndex: 0,
+});
+
+export function setQuery(query: string) {
+    searchState.query = query.trim().toLocaleLowerCase(); // Normalize on setting query to avoid doing it repeatedly in derived stores
+    searchState.selectedIndex = -1;
+    searchState.activeIndex = -1;
+}
+
+const searchTokens = $derived.by(() => searchState.query.split(/\s+/).filter(Boolean));
+const searchResults = $derived.by(() => {
+    if (!searchTokens.length) return [];
+    return searchableSettings.filter(result => searchTokens.every(token => result.searchableText.includes(token)));
+});
+
+export function getResults() {
+    return searchResults;
+}
+
+export function hasResults() {
+    return searchResults.length > 0;
+}
+
+// TODO: this is a bit of a weird place for this, consider moving to a more appropriate utility file
+// also consider precomputing the grouped results instead of doing it on every search, though it is
+// unlikely that there will be enough settings to cause performance issues
+const groupedSearchResults = $derived.by(() => {
+    const grouped: Array<{
+        categoryId: string;
+        categoryName: string;
+        categoryRoute: string;
+        results: Array<SearchResult & {index: number;}>;
+    }> = [];
+
+    searchResults.forEach((result, index) => {
+        const existing = grouped.find(group => group.categoryId === result.categoryId);
+        if (existing) {
+            existing.results.push({...result, index});
+            return;
+        }
+
+        grouped.push({
+            categoryId: result.categoryId,
+            categoryName: result.categoryName,
+            categoryRoute: resolve("/settings/[category]", {category: result.categoryId}),
+            results: [{...result, index}],
+        });
+    });
+
+    return grouped;
+});
+
+export function getGroupedResults() {
+    return groupedSearchResults;
+}
+
+export function hasGroupedResults() {
+    return groupedSearchResults.length > 0;
+}
+
+
+
+export interface SearchResult {
+    categoryId: string;
+    categoryName: string;
+    groupName: string;
+    note: string;
+    routeKey: string;
+    settingId: string;
+    settingName: string;
+    searchableText: string;
+}
+
+// This doesn't belong here
+const stripHtmlRegex = (html: string) => html.replace(/<[^>]*>/g, "");
+
+// TODO: this is pretty inefficient, we should probably build an index for this instead
+// of doing a linear search through all settings every time. However, it is unlikely that
+// there will be enough settings to cause performance issues, so this is good enough for now.
+const searchableSettings = $derived.by(() => {
+    const results: SearchResult[] = [];
+    for (const category of settings) {
+        for (const group of category.groups) {
+            for (const setting of group.settings) {
+                const cleanedNote = setting.note ? stripHtmlRegex(setting.note) : "";
+                const searchableText = [category.name, group.name, setting.name, cleanedNote];
+
+                results.push({
+                    categoryId: category.id,
+                    categoryName: category.name,
+                    groupName: group.name,
+                    note: cleanedNote,
+                    routeKey: `${category.id}:${setting.id}`,
+                    settingId: setting.id,
+                    settingName: setting.name,
+                    searchableText: searchableText.join(" ").toLocaleLowerCase(),
+                });
+            }
+        }
+    }
+    return results;
+});
+
+
+export interface HighlightPart {
+    matched: boolean;
+    text: string;
+}
+
+// TODO: this is a bit janky, consider a more robust solution for keeping track of active/selected
+// search results and their corresponding DOM elements
+export function getHighlightParts(value: string,): HighlightPart[] {
+    if (!value) return [];
+
+    const tokens = searchTokens;
+
+    if (!tokens.length) {
+        return [{matched: false, text: value}];
+    }
+
+    const lowerValue = value.toLocaleLowerCase();
+    const ranges: Array<[number, number]> = [];
+    for (const token of tokens) {
+        if (!token) continue;
+        let fromIndex = 0;
+        while (fromIndex < lowerValue.length) {
+            const index = lowerValue.indexOf(token, fromIndex);
+            if (index < 0) break;
+
+            ranges.push([index, index + token.length]);
+            fromIndex = index + token.length;
+        }
+    }
+
+    if (!ranges.length) {
+        return [{matched: false, text: value}];
+    }
+
+    ranges.sort((a, b) => a[0] - b[0]);
+
+    const merged: Array<[number, number]> = [ranges[0]];
+    for (let i = 1; i < ranges.length; i++) {
+        const range = ranges[i];
+        const last = merged[merged.length - 1];
+        if (range[0] <= last[1]) {
+            last[1] = Math.max(last[1], range[1]);
+        }
+        else {
+            merged.push(range);
+        }
+    }
+
+    const parts: HighlightPart[] = [];
+    let cursor = 0;
+    for (const [start, end] of merged) {
+        if (start > cursor) {
+            parts.push({matched: false, text: value.slice(cursor, start)});
+        }
+        parts.push({matched: true, text: value.slice(start, end)});
+        cursor = end;
+    }
+
+    if (cursor < value.length) {
+        parts.push({matched: false, text: value.slice(cursor)});
+    }
+
+    return parts;
+}

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -29,6 +29,7 @@
     import ModalStack from "$lib/components/modals/ModalStack.svelte";
     import ToastStack from "$lib/components/ToastStack.svelte";
     import type {Snippet} from "svelte";
+    import SettingsSearch from "$lib/components/SettingsSearch.svelte";
 
     const cssConfigVars = $derived.by(() => {
         let str = "";
@@ -82,7 +83,7 @@
                 </div>
             </div>
         </div>
-        <nav id="categories">
+        <SettingsSearch>
             <User route="/" />
             <Gap />
             <Tab route="/settings/application">
@@ -146,7 +147,7 @@
                 {#snippet icon()}<img src={ghostty} alt="Ghostty Website" />{/snippet}
                 Ghostty
             </Tab>
-        </nav>
+        </SettingsSearch>
     </div>
     <div id="content-view">
         {@render children()}
@@ -276,18 +277,18 @@
 
 
 
-#categories {
+/* #categories {
     display: flex;
     flex-direction: column;
     flex: 1;
     padding: 10px;
-}
+} */
 
-#categories img {
+:global(#categories img) {
     width: 100%;
 }
 
-#categories .icon-wrapper {
+:global(#categories .icon-wrapper) {
     background: linear-gradient(#D3E3E9, #908F8C);
     width: 20px;
     height: 20px;
@@ -297,16 +298,16 @@
     align-items: center;
 }
 
-#categories .icon-wrapper img {
+:global(#categories .icon-wrapper img) {
     height: 14px;
     width: 14px;
 }
 
-#categories .icon-wrapper.github {
+:global(#categories .icon-wrapper.github) {
     background: linear-gradient(#9C45A9, #3B1E68);
 }
 
-#categories .icon-wrapper.github img {
+:global(#categories .icon-wrapper.github img) {
     filter: invert(100%);
     height: 18px;
     width: 18px;

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -54,7 +54,7 @@
 
             const duration = token ? 2000 : 2000;
             timeout = window.setTimeout(() => {
-                // settingEl.classList.remove("flash-highlight");
+                settingEl.classList.remove("flash-highlight");
             }, duration);
         });
 

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -23,46 +23,10 @@
     import type {HexColor} from "$lib/utils/colors";
     import {resolve} from "$app/paths";
     import {success} from "$lib/stores/toasts.svelte";
-    import {tick} from "svelte";
 
 
     const category = $derived(settings.find(c => c.id === $page.params.category));
     const title = $derived(category?.name ?? $page.params.category);
-    const targetSettingId = $derived($page.url.searchParams.get("setting") ?? "");
-    const highlightToken = $derived($page.url.searchParams.get("focus") ?? "");
-
-    $effect(() => {
-        const settingId = targetSettingId;
-        const categoryId = category?.id;
-        const token = highlightToken;
-        if (!categoryId || !settingId) return;
-
-        let timeout = 0;
-        let cancelled = false;
-
-        void tick().then(() => {
-            if (cancelled) return;
-
-            const settingEl = document.querySelector<HTMLElement>(`[data-setting-id="${settingId}"]`);
-            if (!settingEl) return;
-
-            settingEl.scrollIntoView({behavior: "smooth", block: "center"});
-
-            settingEl.classList.remove("flash-highlight");
-            void settingEl.offsetWidth;
-            settingEl.classList.add("flash-highlight");
-
-            const duration = token ? 2000 : 2000;
-            timeout = window.setTimeout(() => {
-                settingEl.classList.remove("flash-highlight");
-            }, duration);
-        });
-
-        return () => {
-            cancelled = true;
-            if (timeout) window.clearTimeout(timeout);
-        };
-    });
 </script>
 
 

--- a/src/routes/settings/[category]/+page.svelte
+++ b/src/routes/settings/[category]/+page.svelte
@@ -23,10 +23,46 @@
     import type {HexColor} from "$lib/utils/colors";
     import {resolve} from "$app/paths";
     import {success} from "$lib/stores/toasts.svelte";
+    import {tick} from "svelte";
 
 
     const category = $derived(settings.find(c => c.id === $page.params.category));
     const title = $derived(category?.name ?? $page.params.category);
+    const targetSettingId = $derived($page.url.searchParams.get("setting") ?? "");
+    const highlightToken = $derived($page.url.searchParams.get("focus") ?? "");
+
+    $effect(() => {
+        const settingId = targetSettingId;
+        const categoryId = category?.id;
+        const token = highlightToken;
+        if (!categoryId || !settingId) return;
+
+        let timeout = 0;
+        let cancelled = false;
+
+        void tick().then(() => {
+            if (cancelled) return;
+
+            const settingEl = document.querySelector<HTMLElement>(`[data-setting-id="${settingId}"]`);
+            if (!settingEl) return;
+
+            settingEl.scrollIntoView({behavior: "smooth", block: "center"});
+
+            settingEl.classList.remove("flash-highlight");
+            void settingEl.offsetWidth;
+            settingEl.classList.add("flash-highlight");
+
+            const duration = token ? 2000 : 2000;
+            timeout = window.setTimeout(() => {
+                // settingEl.classList.remove("flash-highlight");
+            }, duration);
+        });
+
+        return () => {
+            cancelled = true;
+            if (timeout) window.clearTimeout(timeout);
+        };
+    });
 </script>
 
 
@@ -55,6 +91,7 @@
                 {#each group.settings as setting, i (setting.id)}
                     {#if i !== 0}<Separator />{/if}
                     <Item
+                        settingId={setting.id}
                         name={setting.name}
                         note={setting.note}
                         // filter out the current platform from the badge list since it's already obvious from the UI


### PR DESCRIPTION
## Human summary:

This supersedes #42 as this is a lot simpler and cleaner in implementation so far. It also looks and feels a lot more like native macOS than the other implementation. As a bonus, this version was not vibe coded, it's human-slop (I still have refactoring and cleaning up to do).

## Clanker summary:

This pull request introduces enhancements to the settings UI, focusing on improved search, navigation, and highlighting of settings, as well as some general component improvements. The main changes include the integration of a `SettingsSearch` component, the ability to highlight and scroll to specific settings, and improved flexibility for the `Tab` and `Item` components.

**Settings search and navigation improvements:**

* Wrapped the settings navigation in a new `SettingsSearch` component, preparing the UI for searching and filtering settings. (`src/routes/+layout.svelte`) [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dR32) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL85-R86) [[3]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL149-R150)
* Modified the settings page to read `setting` and `focus` query parameters, automatically scroll to and highlight the relevant setting in view when these parameters are present. (`src/routes/settings/[category]/+page.svelte`) ([src/routes/settings/[category]/+page.svelteR26-R65](diffhunk://#diff-bc39a48b017e3225d91a19e56f0884c9006fab0f38cafe1fefcfea5a92c52339R26-R65), [src/routes/settings/[category]/+page.svelteR94](diffhunk://#diff-bc39a48b017e3225d91a19e56f0884c9006fab0f38cafe1fefcfea5a92c52339R94))

**Component enhancements:**

* Added an `onClick` prop to the `Tab` component for greater flexibility and improved the logic for determining the selected tab. (`src/lib/components/Tab.svelte`) [[1]](diffhunk://#diff-9122340db0fe5f23ad6ddeecae11c6f819e0cb87c6aa45a21984f53fc907d214R10-R19) [[2]](diffhunk://#diff-9122340db0fe5f23ad6ddeecae11c6f819e0cb87c6aa45a21984f53fc907d214R30)
* Added a `settingId` prop to the `Item` component, rendered as a `data-setting-id` attribute, to support direct referencing and highlighting of settings. (`src/lib/components/settings/Item.svelte`) [[1]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405R14-R20) [[2]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405L56-R57)

**Visual improvements:**

* Implemented a `flash-highlight` animation for settings, visually indicating when a setting is focused or navigated to. (`src/lib/components/settings/Item.svelte`) [[1]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405R115-R139) [[2]](diffhunk://#diff-edef8c268a9c596fd3825b3515388ad879c35b68d151dfba87d08b0d72053405R255-R266)

**Styling adjustments:**

* Updated CSS selectors for category navigation to use global scoping, ensuring styles apply correctly after moving navigation into the `SettingsSearch` component. (`src/routes/+layout.svelte`) [[1]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL279-R291) [[2]](diffhunk://#diff-cc69d6a97e4f62578028d872b8d5032f2786fe1eaa65735429286b375234168dL300-R310)

These changes collectively improve the discoverability and usability of settings, making it easier for users to find and focus on specific options.