### PR TITLE
Add Dockerfile and Docker instructions

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,6 @@
+node_modules
+build
+.svelte-kit
+.git
+.github
+.DS_Store

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,12 @@
+FROM oven/bun:1 AS base
+WORKDIR /app
+
+FROM base AS install
+COPY package.json bun.lock ./
+RUN bun install --frozen-lockfile
+
+FROM base AS dev
+COPY --from=install /app/node_modules ./node_modules
+COPY . .
+EXPOSE 5173
+CMD ["bun", "run", "dev", "--host", "0.0.0.0"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM oven/bun:1 AS base
 WORKDIR /app
 
 FROM base AS install
-COPY package.json bun.lock ./
+COPY package.json bun.lockb ./
 RUN bun install --frozen-lockfile
 
 FROM base AS dev

--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ You can also run the project using Docker without installing Bun locally:
 
 ```bash
 docker build -t ghostty-config .
-docker run -p 5173:5173 ghostty-config
+docker run -p 5173:5173 -v .:/app -v /app/node_modules ghostty-config
 ```
 
 Then open `http://localhost:5173` in your browser.

--- a/README.md
+++ b/README.md
@@ -60,6 +60,18 @@ bun run dev
 ```
 Then open `http://localhost:5173` in your browser when prompted.
 
+
+### Docker
+
+You can also run the project using Docker without installing Bun locally:
+
+```bash
+docker build -t ghostty-config .
+docker run -p 5173:5173 ghostty-config
+```
+
+Then open `http://localhost:5173` in your browser.
+
 Other useful commands:
 ```bash
 bun run build    # production build (output under build/)


### PR DESCRIPTION
## Summary

- Add a multi-stage Dockerfile based on the official `oven/bun` image for running the project in a container
- Add `.dockerignore` to exclude unnecessary files from the build context
- Add Docker usage instructions to the README

## Usage

```bash
docker build -t ghostty-config .
docker run -p 5173:5173 ghostty-config
```

Then open `http://localhost:5173` in your browser.