### PR TITLE
Persist to session storage only

### DIFF
--- a/src/lib/components/Toast.svelte
+++ b/src/lib/components/Toast.svelte
@@ -1,5 +1,5 @@
 <script lang="ts">
-    import {dismissToast} from "$lib/stores/toasts.svelte";
+    import {dismissToast, type ToastAction} from "$lib/stores/toasts.svelte";
     import {sequoiaEase} from "$lib/utils/animations";
     import {fly} from "svelte/transition";
 
@@ -7,19 +7,25 @@
         id: string;
         type: "success" | "error";
         message: string;
+        action?: ToastAction;
     }
 
-    const {id, type, message}: Props = $props();
+    const {id, type, message, action}: Props = $props();
 
     function handleDismiss() {
         dismissToast(id);
     }
 
+    function handleAction() {
+        action?.onClick();
+        dismissToast(id);
+    }
+
 </script>
 
-<div class="toast-container" role="status" aria-live="polite">
-    <!-- eslint-disable-next-line svelte/no-unused-class-name -->
-    <button type="button" class="toast toast-{type}" onclick={handleDismiss} transition:fly={{y: -44, duration: 300, easing: sequoiaEase}}>
+<!-- eslint-disable-next-line svelte/no-unused-class-name -->
+<div class="toast-container toast-{type}" role="status" aria-live="polite" transition:fly={{y: -44, duration: 300, easing: sequoiaEase}}>
+    <button type="button" class="toast" onclick={handleDismiss}>
         <div class="toast-icon">
             {#if type === "success"}
                 <svg width="20" height="20" viewBox="0 0 20 20" fill="none" xmlns="http://www.w3.org/2000/svg">
@@ -39,22 +45,17 @@
         </div>
         <div class="toast-message">{message}</div>
     </button>
+    {#if action}
+        <button type="button" class="toast-action" onclick={handleAction}>{action.label}</button>
+    {/if}
 </div>
 
 <style>
     .toast-container {
         display: flex;
-    }
-
-    .toast {
-        display: flex;
-        align-items: center;
-        gap: 12px;
-        padding: 12px 16px;
+        align-items: stretch;
         min-width: 280px;
         max-width: 400px;
-        width: 100%;
-        border: none;
         border-radius: var(--radius-level-3);
         backdrop-filter: blur(20px);
         -webkit-backdrop-filter: blur(20px);
@@ -62,14 +63,11 @@
             0 4px 16px rgba(0, 0, 0, 0.3),
             0 0 0 1px rgba(255, 255, 255, 0.1) inset,
             0 1px 2px rgba(0, 0, 0, 0.5);
-        cursor: pointer;
         transition: all 0.2s cubic-bezier(0.4, 0.0, 0.2, 1);
-        /* animation: slideIn 0.3s cubic-bezier(0.4, 0.0, 0.2, 1); */
-        font-family: inherit;
-        text-align: left;
+        color: #ffffff;
     }
 
-    .toast:hover {
+    .toast-container:hover {
         transform: translateY(-2px);
         box-shadow:
             0 6px 20px rgba(0, 0, 0, 0.35),
@@ -77,13 +75,55 @@
             0 1px 2px rgba(0, 0, 0, 0.5);
     }
 
-    .toast:focus {
-        outline: none;
-        transform: translateY(-2px);
+    .toast-container:focus-within {
         box-shadow:
             0 6px 20px rgba(0, 0, 0, 0.35),
             0 0 0 2px var(--color-input-accent),
             0 1px 2px rgba(0, 0, 0, 0.5);
+    }
+
+    .toast {
+        display: flex;
+        align-items: center;
+        gap: 12px;
+        padding: 12px 16px;
+        flex: 1;
+        min-width: 0;
+        border: none;
+        border-radius: inherit;
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        font-family: inherit;
+        text-align: left;
+    }
+
+    .toast:focus {
+        outline: none;
+    }
+
+    .toast-action {
+        flex-shrink: 0;
+        border: none;
+        border-left: 1px solid rgba(255, 255, 255, 0.25);
+        border-radius: 0 var(--radius-level-3) var(--radius-level-3) 0;
+        /* background: rgba(255, 255, 255, 0.12); */
+        background: transparent;
+        color: inherit;
+        cursor: pointer;
+        padding: 0 16px;
+        font-family: inherit;
+        font-size: 14px;
+        font-weight: 600;
+        letter-spacing: -0.01em;
+    }
+
+    .toast-action:hover {
+        background: rgba(255, 255, 255, 0.22);
+    }
+
+    .toast-action:focus {
+        outline: none;
     }
 
     .toast-success {
@@ -92,7 +132,6 @@
             rgba(52, 199, 89, 0.85) 0%,
             rgba(48, 176, 79, 0.85) 100%
         );
-        color: #ffffff;
     }
 
     .toast-error {
@@ -101,7 +140,6 @@
             rgba(255, 69, 58, 0.85) 0%,
             rgba(235, 61, 50, 0.85) 100%
         );
-        color: #ffffff;
     }
 
     .toast-icon {

--- a/src/lib/components/ToastStack.svelte
+++ b/src/lib/components/ToastStack.svelte
@@ -7,7 +7,7 @@
 
 <div class="toast-stack">
     {#each toasts as toast (toast.id)}
-        <Toast id={toast.id} type={toast.type} message={toast.message} />
+        <Toast id={toast.id} type={toast.type} message={toast.message} action={toast.action} />
     {/each}
 </div>
 

--- a/src/lib/stores/config.svelte.test.ts
+++ b/src/lib/stores/config.svelte.test.ts
@@ -87,6 +87,32 @@ describe("load()", () => {
     });
 });
 
+describe("load() idempotency (session-restore cycle)", () => {
+    // The persisted diff carries only non-default keybinds; restoring it re-runs load(), which
+    // appends. Two loads of the same additions (a double restore, or restore-then-persist-restore)
+    // must not duplicate — otherwise every refresh grows the keybind list. Palette merges
+    // per-index and is idempotent by construction; covered here in the same cycle.
+    const sparsePalette = (index: number, color: string) => {
+        const arr = Array.from<string>({length: 256}).fill("");
+        arr[index] = color;
+        return arr;
+    };
+
+    it("does not duplicate keybinds across repeated loads", () => {
+        const custom = "ctrl+shift+x=copy_to_clipboard" as const;
+        load({keybind: [custom]});
+        load({keybind: [custom]});
+        expect(config.keybind.filter(k => k === custom)).toHaveLength(1);
+    });
+
+    it("merges palette slots idempotently", () => {
+        load({palette: sparsePalette(5, "#ffffff")});
+        load({palette: sparsePalette(5, "#ffffff")});
+        expect(config.palette[5]).toBe("#ffffff");
+        expect(diff().palette).toEqual(["5=#ffffff"]);
+    });
+});
+
 describe("round-trip diff -> serialize", () => {
     it("renders a flat diff as Ghostty config lines", () => {
         config.fontSize = "18";

--- a/src/lib/stores/config.svelte.ts
+++ b/src/lib/stores/config.svelte.ts
@@ -63,7 +63,13 @@ export function load(conf: Partial<typeof config>) {
             setSetting(key as keyof typeof config, conf[key as keyof typeof config]!);
         }
         else if (key === "keybind") {
-            config.keybind = [...config.keybind, ...conf.keybind!];
+            // Dedup on append: skip keybinds already present. load() runs on every import
+            // source (share, clipboard, file, session restore); without this, restoring a
+            // persisted session — whose diff already carries the non-default keybinds —
+            // would re-append them each cycle and duplicate custom binds. Palette (below)
+            // merges per-index and is naturally idempotent.
+            const additions = conf.keybind!.filter(k => !config.keybind.includes(k));
+            if (additions.length) config.keybind = [...config.keybind, ...additions];
         }
         else if (key === "palette") {
             for (let p = 0; p < conf.palette!.length; p++) {
@@ -89,6 +95,11 @@ export function setSetting<K extends keyof SettingValues>(key: K, value: Setting
 export function resetSetting(key: keyof SettingValues) {
     const defaultValue = defaults[key];
     setSetting(key, Array.isArray(defaultValue) ? [...defaultValue] : defaultValue);
+}
+
+/** Reset every setting to its registry default. Config-state only — touches nothing else. */
+export function resetAllSettings() {
+    for (const key in defaults) resetSetting(key as keyof SettingValues);
 }
 
 export function isNonDefault(key: keyof SettingValues): boolean {

--- a/src/lib/stores/persistence.svelte.test.ts
+++ b/src/lib/stores/persistence.svelte.test.ts
@@ -1,0 +1,93 @@
+import {afterEach, describe, expect, it, vi} from "vitest";
+
+// Covers the session refresh-protection *restore/clear* surface in persistence store: the
+// no-window/no-storage guards, the parse()/load() restore path, empty-string (pristine after
+// reset) handling, corrupt-payload discard, and end-to-end restore idempotency (a double
+// restore must not duplicate keybinds, the load() dedup is exercised here through the real
+// persistence path). The debounced write effect's reactive timing is intentionally not unit
+// tested; it is thin and exercised in the running app.
+
+import config, {defaults, diff, resetAllSettings, resetSetting} from "$lib/stores/config.svelte";
+import {serialize} from "$lib/utils/parse";
+import {clearPersistedSession, restorePersistedSession, SESSION_KEY} from "./persistence.svelte";
+
+function makeStorage(): Storage {
+    const map = new Map<string, string>();
+    return {
+        getItem: (k: string) => (map.has(k) ? map.get(k)! : null),
+        setItem: (k: string, v: string) => void map.set(k, String(v)),
+        removeItem: (k: string) => void map.delete(k),
+        clear: () => map.clear(),
+        key: (i: number) => Array.from(map.keys())[i] ?? null,
+        get length() {
+            return map.size;
+        }
+    };
+}
+
+function stubSession(storage: Storage = makeStorage()) {
+    vi.stubGlobal("window", {sessionStorage: storage});
+    return storage;
+}
+
+afterEach(() => {
+    resetAllSettings();
+    vi.unstubAllGlobals();
+});
+
+describe("restorePersistedSession", () => {
+    it("no-ops (no throw, no mutation) when there is no window", () => {
+        expect(() => restorePersistedSession()).not.toThrow();
+        expect(config.fontSize).toBe(defaults.fontSize);
+    });
+
+    it("restores a persisted diff into the live store via the import path", () => {
+        const storage = stubSession();
+        storage.setItem(SESSION_KEY, "font-size = 20\nbackground = #123456");
+
+        restorePersistedSession();
+
+        expect(config.fontSize).toBe("20");
+        expect(config.background).toBe("#123456");
+    });
+
+    it("treats an empty persisted value as pristine (nothing loaded)", () => {
+        const storage = stubSession();
+        storage.setItem(SESSION_KEY, "");
+
+        restorePersistedSession();
+
+        expect(config.fontSize).toBe(defaults.fontSize);
+    });
+
+    it("is idempotent across repeated restores — no duplicated keybinds", () => {
+        const storage = stubSession();
+        config.keybind = [...defaults.keybind, "ctrl+shift+x=copy_to_clipboard"];
+        // Persist exactly what the write path would: the serialized diff (additions only).
+        storage.setItem(SESSION_KEY, serialize(diff(), false));
+
+        // Simulate a fresh session (module state reset) then two restores in a row.
+        resetSetting("keybind");
+        restorePersistedSession();
+        restorePersistedSession();
+
+        expect(config.keybind.filter(k => k === "ctrl+shift+x=copy_to_clipboard")).toHaveLength(1);
+    });
+});
+
+describe("clearPersistedSession", () => {
+    it("removes the persisted key so a later restore is pristine", () => {
+        const storage = stubSession();
+        storage.setItem(SESSION_KEY, "font-size = 20");
+
+        clearPersistedSession();
+        expect(storage.getItem(SESSION_KEY)).toBeNull();
+
+        restorePersistedSession();
+        expect(config.fontSize).toBe(defaults.fontSize);
+    });
+
+    it("no-ops without a window", () => {
+        expect(() => clearPersistedSession()).not.toThrow();
+    });
+});

--- a/src/lib/stores/persistence.svelte.ts
+++ b/src/lib/stores/persistence.svelte.ts
@@ -1,0 +1,101 @@
+import {dev} from "$app/environment";
+
+import {diff, load} from "$lib/stores/config.svelte";
+import {parse, serialize} from "$lib/utils/parse";
+import {debounce} from "$lib/utils/debounce";
+
+// Session-scoped refresh protection. We persist the *serialized diff text* (never the store
+// object) under a versioned key for the lifetime of the browsing session only, i.e. refresh/tab
+// reload restores in-progress work; closing the tab (new session) starts pristine. Rationale
+// for storing diff text rather than state: restore reuses the existing parse()/load() import
+// path, the stored text is forward-compatible kebab-key config, only deltas are stored so
+// registry-default changes flow through, and theme colors can never leak in (they are derived,
+// never written to the store). This module intentionally knows about config; config must NOT
+// know about persistence as the dependency points one way.
+
+export const SESSION_KEY = "ghostty-config:session:v1";
+const WRITE_DEBOUNCE_MS = 300;
+
+function sessionStore(): Storage | null {
+    if (typeof window === "undefined") return null;
+    try {
+        return window.sessionStorage;
+    }
+    catch {
+        // sessionStorage can throw on access in some privacy modes.
+        return null;
+    }
+}
+
+/** Remove the persisted session entirely. Used by the global "Reset all" control. */
+export function clearPersistedSession() {
+    const store = sessionStore();
+    if (!store) return;
+    try {
+        store.removeItem(SESSION_KEY);
+    }
+    catch {/* ignore */}
+}
+
+/**
+ * Restore any persisted session into the live store via the normal import path. Silent by
+ * design... Same-session state is never surprising, so there is no toast or restore notice.
+ * Must run before any share-hash import preview is built so the modal's "importing will
+ * overwrite your changes" framing is truthful against the restored state.
+ */
+export function restorePersistedSession() {
+    const store = sessionStore();
+    if (!store) return;
+
+    let text: string | null;
+    try {
+        text = store.getItem(SESSION_KEY);
+    }
+    catch {
+        return;
+    }
+    // Empty string = a persisted-but-pristine session (e.g. after a reset). Nothing to load.
+    if (!text) return;
+
+    try {
+        load(parse(text));
+    }
+    catch (err) {
+        // Corrupt session text, discard it. Blast radius is a single session, so no `:backup` ceremony. Just drop it and continue from defaults.
+        if (dev) console.error("Failed to restore persisted session:", err); // eslint-disable-line no-console
+        clearPersistedSession();
+    }
+}
+
+let stopEffect: (() => void) | null = null;
+
+/**
+ * Begin persisting the working config to sessionStorage on every change (debounced,
+ * trailing-edge so the final state wins). Idempotent and a no-op without sessionStorage
+ * (SSR/prerender, privacy modes).
+ */
+export function startPersisting() {
+    const store = sessionStore();
+    if (!store || stopEffect) return;
+
+    const write = debounce(() => {
+        try {
+            store.setItem(SESSION_KEY, serialize(diff(), false));
+        }
+        catch {/* quota / privacy — best-effort */}
+    }, WRITE_DEBOUNCE_MS, {leading: false, trailing: true});
+
+    stopEffect = $effect.root(() => {
+        $effect(() => {
+            // diff() touches every config key, so this effect reruns on any config change.
+            diff();
+            write();
+        });
+    });
+}
+
+/** Tear down the persistence effect. Primarily for tests. */
+export function stopPersisting() {
+    stopEffect?.();
+    stopEffect = null;
+}

--- a/src/lib/stores/toasts.svelte.ts
+++ b/src/lib/stores/toasts.svelte.ts
@@ -1,15 +1,22 @@
 type ToastType = "success" | "error";
 
+export interface ToastAction {
+    label: string;
+    onClick: () => void;
+}
+
 type ToastRequest = {
     id: string;
     type: ToastType;
     message: string;
     duration: number;
+    action?: ToastAction;
 };
 
 interface ToastOptions {
     message: string;
     duration?: number;
+    action?: ToastAction;
 }
 
 const DEFAULT_DURATION = 3000;
@@ -33,12 +40,14 @@ export function getToasts() {
 function addToast(options: ToastOptions | string, type: ToastType) {
     const message = typeof options === "string" ? options : options.message;
     const duration = typeof options === "string" ? DEFAULT_DURATION : options.duration ?? DEFAULT_DURATION;
+    const action = typeof options === "string" ? undefined : options.action;
 
     const toast: ToastRequest = {
         id: getNextId(),
         type,
         message,
-        duration
+        duration,
+        action
     };
 
     toastStack = [toast, ...toastStack];

--- a/src/routes/+layout.svelte
+++ b/src/routes/+layout.svelte
@@ -24,6 +24,16 @@
     import {resolveCellColor} from "$lib/utils/colors";
     import app from "$lib/stores/state.svelte";
     import navigation, {tabGroups} from "$lib/settings/navigation";
+    import {restorePersistedSession, startPersisting} from "$lib/stores/persistence.svelte";
+
+
+    // Session refresh-protection. Run synchronously during layout init (the root component)
+    // so restore completes before any page's onMount fires — in particular before the
+    // import-export page's checkHashForShare() builds a share-import preview, keeping that
+    // modal's "will overwrite your changes" framing truthful against the restored state.
+    // No-op on the server (prerender); config's sync initializers have already run by import.
+    restorePersistedSession();
+    startPersisting();
 
 
     // The single funnel for the color keys: everything below reads the *effective* colors

--- a/src/routes/app/import-export/+page.svelte
+++ b/src/routes/app/import-export/+page.svelte
@@ -2,9 +2,10 @@
     import Group from "$lib/components/settings/Group.svelte";
     import Item from "$lib/components/settings/Item.svelte";
     import Separator from "$lib/components/settings/Separator.svelte";
-    import {diff} from "$lib/stores/config.svelte";
+    import {diff, load, resetAllSettings} from "$lib/stores/config.svelte";
+    import {clearPersistedSession} from "$lib/stores/persistence.svelte";
     // import {alert as showAlert} from "$lib/stores/modals.svelte";
-    import {serialize} from "$lib/utils/parse";
+    import {parse, serialize} from "$lib/utils/parse";
     import {buildShareUrl, encodeConfig, MAX_SHARE_URL_LENGTH} from "$lib/utils/share";
     import Page from "$lib/views/Page.svelte";
     import Button from "$lib/components/Button.svelte";
@@ -81,6 +82,27 @@
         URL.revokeObjectURL(url);
         success("Config file downloaded");
     }, 300);
+
+
+    // Reset all — the app's explicit global reset. Refresh used to be the de-facto "reset
+    // everything" gesture; session persistence removed that, so this restores it deliberately.
+    // Guarded by an Undo action on the success toast (captured diff is re-imported on undo).
+    function resetAll() {
+        if (!hasExportableConfig) return;
+
+        const captured = serialize(currentConfigDiff, false);
+        clearPersistedSession();
+        resetAllSettings();
+
+        success({
+            message: "All settings reset to defaults",
+            duration: 8000,
+            action: {
+                label: "Undo",
+                onClick: () => load(parse(captured))
+            }
+        });
+    }
 
 
     // Share Composer Modal Logic
@@ -163,6 +185,17 @@
                     title={hasExportableConfig ? "Share your config" : "No changes yet!"}
                     disabled={!hasExportableConfig}
                 >Share</Button>
+            </div>
+        </Item>
+    </Group>
+    <Group title="Reset">
+        <Item name="Reset All Settings" note="Return every setting to its default. You can undo this right after.">
+            <div class="button-group">
+                <Button
+                    onclick={resetAll}
+                    title={hasExportableConfig ? "Reset all settings to defaults" : "No changes yet!"}
+                    disabled={!hasExportableConfig}
+                >Reset All</Button>
             </div>
         </Item>
     </Group>


### PR DESCRIPTION
## Summary

Persists config to session storage _only_ that way a reload or accidental navigation doesn't clear everything. Also adds a reset all button with an undo via toasts.

## Type of change

<!-- Check all that apply -->

- [ ] Bug fix
- [ ] New or updated setting
- [x] UI / component change
- [ ] Refactor (no behavior change)
- [ ] Documentation
- [x] Other: New feature 

## Testing

<!-- What did you manually verify? For UI changes, include a screenshot or recording. -->

- [ ] `bun run check` passes
- [ ] `bun run lint` passes
- [ ] `bun run test` passes

## AI disclosure

<!-- See CONTRIBUTING.md for the full expectation. Check whichever applies. -->

- [x] I did not use AI assistance for this PR
- [ ] I used AI assistance and personally reviewed all generated output before submitting
- [ ] An AI agent generated part or all of this PR with minimal personal review. Details: <!-- describe what was generated and what (if anything) you reviewed -->